### PR TITLE
武器３対応

### DIFF
--- a/Assets/Prefabs/Sickle.prefab
+++ b/Assets/Prefabs/Sickle.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1561429822502233149}
   - component: {fileID: 1482558153878562568}
   - component: {fileID: 8588129571662490371}
+  - component: {fileID: 4173894813721425014}
   m_Layer: 0
   m_Name: Sickle
   m_TagString: Weapon
@@ -148,3 +149,15 @@ CircleCollider2D:
   m_Offset: {x: 0.19999993, y: -0.05000008}
   serializedVersion: 2
   m_Radius: 0.5
+--- !u!114 &4173894813721425014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3040417762749310419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 245667e6aa2e14327b3f8a78fc5dd15d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1462,6 +1462,7 @@ MonoBehaviour:
   playerController: {fileID: 386879982}
   weapon_1: {fileID: 1055049789}
   weapon_2: {fileID: 864418275}
+  weapon_3: {fileID: 1360534124}
 --- !u!4 &682825269
 Transform:
   m_ObjectHideFlags: 0
@@ -2416,6 +2417,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1360534123}
+  - component: {fileID: 1360534124}
   m_Layer: 0
   m_Name: weapon_3
   m_TagString: Untagged
@@ -2439,6 +2441,22 @@ Transform:
   - {fileID: 1509225102}
   m_Father: {fileID: 682825269}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1360534124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1360534122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6859ccae1e649462abe282b4344a3c43, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerController: {fileID: 386879982}
+  enemyController: {fileID: 365266726}
+  prefab: {fileID: 3040417762749310419, guid: 3bbbe70dd5c7542a9b86212897b539e2, type: 3}
+  parent: {fileID: 1509225102}
 --- !u!1 &1451293196
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -9,6 +9,9 @@ public class PlayerController : MonoBehaviour
 {
     // プレイヤー
     [SerializeField] private Player player;
+    // プレイヤーの取得
+    public Player GetPlayer() { return player; }
+    
     // 武器管理
     [SerializeField] private WeaponController weaponController;
 

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 鎌（農具）
+/// </summary>
+public class Sickle : MonoBehaviour
+{
+/*
+    void Start()
+    {
+        // 初期化
+        Initialize(0.0f);
+    }
+*/
+
+    // 半径
+    public const float Radius = 4.0f;
+    // 回転速度（秒間）
+    private const float RotateSpeed = 270f;
+    // 自転速度（秒間）
+    private const float SpinSpeed   = 1080f;
+
+    // 角度（位置を決定するための角度）
+    private float rotateAngle = 0.0f;
+    // 角度（自転）
+    private float spinAngle = 0.0f;
+
+    // プレイヤー
+    private Player player;
+
+    /// <summary>
+    /// 初期化
+    /// </summary>
+    /// <param name="player">プレイヤー</param>
+    /// <param name="rot">初期角度</param>
+    public void Initialize(Player player, float rot)
+    {
+        rotateAngle = rot;
+        spinAngle = 0.0f;
+        this.player = player;
+    }
+
+    /// <summary>
+    /// フレームワーク
+    /// </summary>
+    void Update()
+    {
+        // 角度（公転）を増加
+        rotateAngle -= RotateSpeed * Time.deltaTime;
+        // 角度（自転）を増加
+        spinAngle -= SpinSpeed * Time.deltaTime;
+
+        // 角度（公転）をラジアンに変換
+        float rad = rotateAngle * Mathf.Deg2Rad;
+        // 角度（自転）をラジアンに変換
+        float spinRad = spinAngle * Mathf.Deg2Rad;
+
+        // 位置を更新
+        Vector2 pos = player.Position;
+        transform.position = new Vector3(
+            pos.x + Radius * Mathf.Cos(rad),
+            pos.y + Radius * Mathf.Sin(rad),
+            0.0f
+        );
+
+        // 回転を更新
+        transform.rotation = Quaternion.Euler(0.0f, 0.0f, spinAngle);
+    }
+
+
+}

--- a/Assets/Scripts/Sickle.cs.meta
+++ b/Assets/Scripts/Sickle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 245667e6aa2e14327b3f8a78fc5dd15d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WeaponController.cs
+++ b/Assets/Scripts/WeaponController.cs
@@ -37,6 +37,8 @@ public class WeaponController : MonoBehaviour
     [SerializeField] private Weapon_1 weapon_1;
     // 武器２（すき）
     [SerializeField] private Weapon_2 weapon_2;
+    // 武器３（鎌）
+    [SerializeField] private Weapon_3 weapon_3;
 
     /// <summary>
     /// 開始時処理
@@ -67,6 +69,27 @@ public class WeaponController : MonoBehaviour
             setWeapon2Level();
         });
 
+        // 武器３のボタンイベント設定
+        weaponInterface[(int)WeaponType.Weapon_3].btnDown.onClick.AddListener(() =>
+        {
+            // レベルダウン（非アクティブの場合は何もしない）
+            if (weapon_3.IsActive())
+            {
+                weapon_3.LevelDown();
+                weapon_3.CreateAndInitialize(playerController.GetPlayer());
+                setWeapon3Level();
+            }
+        });
+        weaponInterface[(int)WeaponType.Weapon_3].btnUp.onClick.AddListener(() =>
+        {
+            // 非アクティブの場合はアクティブ化
+            if (!weapon_3.IsActive())   weapon_3.Activate();
+            // レベルアップ
+            else                        weapon_3.LevelUp();
+            weapon_3.CreateAndInitialize(playerController.GetPlayer());
+            setWeapon3Level();
+        });
+
     }
 
     /// <summary>
@@ -82,4 +105,11 @@ public class WeaponController : MonoBehaviour
     {
         weaponInterface[(int)WeaponType.Weapon_2].txtLevel.text = (weapon_2.GetLevel() + 1).ToString();  // 表示はプラス１する
     }
+
+    // 武器３のレベル表示
+    private void setWeapon3Level()
+    {
+        weaponInterface[(int)WeaponType.Weapon_3].txtLevel.text = (weapon_3.GetLevel() + 1).ToString();  // 表示はプラス１する
+    }
+
 }

--- a/Assets/Scripts/Weapon_3.cs
+++ b/Assets/Scripts/Weapon_3.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 武器３・鎌（農具）
+/// </summary>
+public class Weapon_3 : WeaponBase
+{
+    // 同時出現数（３レベル）
+    private readonly int[] simultaneous = { 1, 2, 3 };
+    private readonly float[] relativeAngles = { 0.0f, 180.0f, 120.0f };
+
+    // 生成済みの鎌
+    private List<GameObject> sickles = new List<GameObject>();
+
+    /// <summary>
+    /// 生成と初期配置
+    /// </summary>
+    /// <param name="player">プレイヤー</param>
+    public void CreateAndInitialize(Player player)
+    {
+        float rot = 0.0f;
+        // 生成済みの鎌の数を取得
+        int existNum = sickles.Count;
+        // 生成する鎌の数を取得
+        int num = simultaneous[GetLevel()];
+
+        for(int i=0 ; i<num ; i++)
+        {
+            GameObject sickle = null;
+            // 生成済みの鎌がある場合は、List から取得
+            if(i < existNum)
+            {
+                sickle = sickles[i];
+            }
+            // 鎌を生成
+            else
+            {
+                sickle = Instantiate(prefab, parent);
+                sickles.Add(sickle);
+            }
+            // 初期化
+            sickle.GetComponent<Sickle>().Initialize(player, rot);
+            rot += relativeAngles[GetLevel()];
+        }
+
+        // 生成済みの鎌の数が生成する鎌の数より多い場合は、削除
+        for(int i=num ; i<existNum ; i++)
+        {
+            Destroy(sickles[i]);
+            sickles.RemoveAt(i);
+        }
+
+    }
+
+
+}

--- a/Assets/Scripts/Weapon_3.cs.meta
+++ b/Assets/Scripts/Weapon_3.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6859ccae1e649462abe282b4344a3c43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 武器３の挙動を追加
・プレイヤーの同心円上を移動する
・武器自身も回転している

### 武器３のレベルによる個数を変更
・レベル１→1個
・レベル２→2個
・レベル３→3個

### 武器UI でレベルを増減