### PR TITLE
武器３（鎌）の使用不可時間を追加

### DIFF
--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -29,10 +29,10 @@ public class EnemyController : MonoBehaviour
     /// </summary>
     private IEnumerator spawnBase()
     {
-        const int MAX_BASE_ENEMYS  = 20;
+        const int MAX_BASE_ENEMYS  = 50;
         const float spawnRadiusMin = 5.0f;
         const float spawnRadiusMax = 10.0f;
-        const float spawnInterval  = 1f;
+        const float spawnInterval  = 0.5f;
         var waitTime = new WaitForSeconds(spawnInterval);
         while(true)
         {
@@ -55,7 +55,7 @@ public class EnemyController : MonoBehaviour
 
     private IEnumerator spawnWave()
     {
-        const float spawnInterval = 20;
+        const float spawnInterval = 10;
         const float MaxSpawnNum = 200;
         var waitTime = new WaitForSeconds(spawnInterval);
         int wave = 0;

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 /// <summary>
 /// 鎌（農具）
@@ -18,7 +19,7 @@ public class Sickle : MonoBehaviour
     // 半径
     public const float Radius = 4.0f;
     // 回転速度（秒間）
-    private const float RotateSpeed = 90f;
+    private const float RotateSpeed = 180f;
     // 自転速度（秒間）
     private const float SpinSpeed   = 1080f;
 
@@ -69,5 +70,21 @@ public class Sickle : MonoBehaviour
         transform.rotation = Quaternion.Euler(0.0f, 0.0f, spinAngle);
     }
 
+    /// <summary>
+    /// コライダーが当たったら最初に呼ばれる
+    /// </summary>
+    /// <param name="collision">相手側の情報が格納される</param>
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        // Enemy に当たったら消滅
+        if (collision.tag == "Enemy")
+        {
+            // 親オブジェクトへ通知
+            OnHit.Invoke();
+        }
+    }
+
+    // ヒット時に呼ばれるイベント
+    public UnityEvent OnHit = new UnityEvent();
 
 }

--- a/Assets/Scripts/Weapon_3.cs
+++ b/Assets/Scripts/Weapon_3.cs
@@ -10,6 +10,9 @@ public class Weapon_3 : WeaponBase
     // 同時出現数（３レベル）
     private readonly int[] simultaneous = { 1, 2, 3 };
     private readonly float[] relativeAngles = { 0.0f, 180.0f, 120.0f };
+    private readonly int[] hitMaxes = { 5, 15, 30 };
+    private int curHit = 0;
+    private readonly int waitTime = 5;
 
     // 生成済みの鎌
     private List<GameObject> sickles = new List<GameObject>();
@@ -43,6 +46,9 @@ public class Weapon_3 : WeaponBase
             // 初期化
             sickle.GetComponent<Sickle>().Initialize(player, rot);
             rot += relativeAngles[GetLevel()];
+
+            // 当たり判定を監視し、
+            sickle.GetComponent<Sickle>().OnHit.AddListener(() => Hit(sickle));
         }
 
         // 生成済みの鎌の数が生成する鎌の数より多い場合は、削除
@@ -51,8 +57,41 @@ public class Weapon_3 : WeaponBase
             Destroy(sickles[i]);
             sickles.RemoveAt(i);
         }
-
     }
 
+    /// <summary>
+    /// 当たり判定が発生したら呼ばれる
+    /// </summary>
+    /// <param name="sickle"></param>
+    private void Hit(GameObject sickle)
+    {
+        curHit++;
+        if(curHit >= hitMaxes[GetLevel()])
+        {
+            // ヒット数をリセット
+            curHit = 0;
+            // 武器を非アクティブにする
+            for(int i=0 ; i<sickles.Count ; i++)
+            {
+                sickles[i].SetActive(false);
+            }
 
+            // 待機時間後に再度アクティブにする
+            StartCoroutine(WaitActive());
+        }
+    }
+
+    /// <summary>
+    /// 使用不可時間
+    /// </summary>
+    /// <returns>こルーチン</returns>
+    private IEnumerator WaitActive()
+    {
+        yield return new WaitForSeconds(waitTime);
+
+        for(int i=0 ; i<sickles.Count ; i++)
+        {
+            sickles[i].SetActive(true);
+        }
+    }
 }


### PR DESCRIPTION
### 武器３（鎌）の使用不可時間を追加
- レベルに応じて討伐上限を設定
- 討伐上限を超えたら鎌を非アクティブ化
- 5秒経過でアクティブ化