### PR TITLE
経験値と武器レベルアップボードの対応

### DIFF
--- a/Assets/Prefabs/exp.prefab
+++ b/Assets/Prefabs/exp.prefab
@@ -1,0 +1,102 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &11022837396415520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5184037780259149511}
+  - component: {fileID: 2547597275840355670}
+  - component: {fileID: 5700797992528639974}
+  m_Layer: 0
+  m_Name: exp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5184037780259149511
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11022837396415520}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.8}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2547597275840355670
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11022837396415520}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -1997803578, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.5555556, y: 0.6111111}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &5700797992528639974
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 11022837396415520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 193bb340963074ddead5e1dafcbfc42a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnDeleted:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Prefabs/exp.prefab.meta
+++ b/Assets/Prefabs/exp.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 022891dd1112d45a58b6f056786abeb6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -287,6 +287,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerController: {fileID: 386879982}
+  expController: {fileID: 918975131}
   enemyPrefabs:
   - {fileID: 1417766533275593788, guid: c5b459ee3e3f84ae99d028d6d403bcff, type: 3}
   - {fileID: 2194842702961310431, guid: 563dc165ab0364d1c8aca3c1f321217f, type: 3}
@@ -1685,6 +1686,54 @@ MonoBehaviour:
   enemyController: {fileID: 365266726}
   prefab: {fileID: 9193252990838036264, guid: d4082eafb81fa4d90ba02fbd3a0058eb, type: 3}
   parent: {fileID: 1260876362}
+--- !u!1 &918975130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 918975132}
+  - component: {fileID: 918975131}
+  m_Layer: 0
+  m_Name: ExpController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &918975131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918975130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0874a2d80d17a43568af7ccb467cc4aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerController: {fileID: 386879982}
+  prefab: {fileID: 11022837396415520, guid: 022891dd1112d45a58b6f056786abeb6, type: 3}
+  parent: {fileID: 1243791209}
+--- !u!4 &918975132
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 918975130}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1243791210}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &930437192
 GameObject:
   m_ObjectHideFlags: 0
@@ -2298,6 +2347,37 @@ MonoBehaviour:
   mainCamera: {fileID: 519420031}
   playerController: {fileID: 386879982}
   fieldController: {fileID: 961630575}
+--- !u!1 &1243791209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1243791210}
+  m_Layer: 0
+  m_Name: exps
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1243791210
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1243791209}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 918975132}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1249577202
 GameObject:
   m_ObjectHideFlags: 0
@@ -3531,6 +3611,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: player
       objectReference: {fileID: 0}
+    - target: {fileID: 8763910623803662693, guid: 555213a745cf641b8a7690de336062d5, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3563,3 +3647,4 @@ SceneRoots:
   - {fileID: 1227936011}
   - {fileID: 365266725}
   - {fileID: 961630574}
+  - {fileID: 918975132}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -123,6 +123,163 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &36857841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 36857842}
+  - component: {fileID: 36857844}
+  - component: {fileID: 36857843}
+  m_Layer: 5
+  m_Name: Weapon3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &36857842
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36857841}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1087212108}
+  - {fileID: 1167216999}
+  - {fileID: 249247540}
+  m_Father: {fileID: 1063520834}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &36857843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36857841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.77254903, g: 0.47060168, b: 0.3764706, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &36857844
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36857841}
+  m_CullTransparentMesh: 1
+--- !u!1 &46778524
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 46778525}
+  - component: {fileID: 46778527}
+  - component: {fileID: 46778526}
+  m_Layer: 5
+  m_Name: Text_lv2 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &46778525
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46778524}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1063674510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &46778526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46778524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &46778527
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 46778524}
+  m_CullTransparentMesh: 1
 --- !u!1 &87451787
 GameObject:
   m_ObjectHideFlags: 0
@@ -202,6 +359,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 87451787}
   m_CullTransparentMesh: 1
+--- !u!1 &107593067
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 107593068}
+  - component: {fileID: 107593070}
+  - component: {fileID: 107593069}
+  m_Layer: 5
+  m_Name: Text_lv3 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &107593068
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107593067}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 249247540}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &107593069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107593067}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &107593070
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107593067}
+  m_CullTransparentMesh: 1
 --- !u!1 &147930652
 GameObject:
   m_ObjectHideFlags: 0
@@ -241,6 +477,44 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -128}
   m_SizeDelta: {x: 428, y: 128}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &249247539
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 249247540}
+  m_Layer: 5
+  m_Name: Level  (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &249247540
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249247539}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 842924156}
+  - {fileID: 882256263}
+  - {fileID: 107593068}
+  m_Father: {fileID: 36857842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &365266724
 GameObject:
   m_ObjectHideFlags: 0
@@ -340,6 +614,126 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 2139378543}
   weaponController: {fileID: 682825268}
+--- !u!1 &407167086
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 407167087}
+  - component: {fileID: 407167090}
+  - component: {fileID: 407167089}
+  - component: {fileID: 407167088}
+  m_Layer: 5
+  m_Name: Button (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &407167087
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407167086}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1686196332}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &407167088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407167086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 407167089}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &407167089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407167086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1772703093, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &407167090
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407167086}
+  m_CullTransparentMesh: 1
 --- !u!1 &412406945
 GameObject:
   m_ObjectHideFlags: 0
@@ -607,6 +1001,126 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 435390705}
+  m_CullTransparentMesh: 1
+--- !u!1 &463044343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 463044344}
+  - component: {fileID: 463044347}
+  - component: {fileID: 463044346}
+  - component: {fileID: 463044345}
+  m_Layer: 5
+  m_Name: Button (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &463044344
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463044343}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1630750910}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &463044345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463044343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 463044346}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &463044346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463044343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -1972582131, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &463044347
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463044343}
   m_CullTransparentMesh: 1
 --- !u!1 &473648026
 GameObject:
@@ -1561,6 +2075,164 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 687271092}
   m_CullTransparentMesh: 1
+--- !u!1 &750244412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 750244413}
+  - component: {fileID: 750244415}
+  - component: {fileID: 750244414}
+  m_Layer: 5
+  m_Name: Text_lv1 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &750244413
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750244412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1471812024}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &750244414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750244412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2605"
+--- !u!222 &750244415
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 750244412}
+  m_CullTransparentMesh: 1
+--- !u!1 &779781468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 779781469}
+  - component: {fileID: 779781471}
+  - component: {fileID: 779781470}
+  m_Layer: 5
+  m_Name: Text_lv1 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &779781469
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 779781468}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1063674510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &779781470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 779781468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: " \u2606"
+--- !u!222 &779781471
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 779781468}
+  m_CullTransparentMesh: 1
 --- !u!1 &832843613
 GameObject:
   m_ObjectHideFlags: 0
@@ -1637,6 +2309,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 832843613}
   m_CullTransparentMesh: 1
+--- !u!1 &842924155
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 842924156}
+  - component: {fileID: 842924158}
+  - component: {fileID: 842924157}
+  m_Layer: 5
+  m_Name: Text_lv1 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &842924156
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842924155}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 249247540}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &842924157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842924155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: " \u2606"
+--- !u!222 &842924158
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842924155}
+  m_CullTransparentMesh: 1
 --- !u!1 &864418273
 GameObject:
   m_ObjectHideFlags: 0
@@ -1686,6 +2437,85 @@ MonoBehaviour:
   enemyController: {fileID: 365266726}
   prefab: {fileID: 9193252990838036264, guid: d4082eafb81fa4d90ba02fbd3a0058eb, type: 3}
   parent: {fileID: 1260876362}
+--- !u!1 &882256262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 882256263}
+  - component: {fileID: 882256265}
+  - component: {fileID: 882256264}
+  m_Layer: 5
+  m_Name: Text_lv2 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &882256263
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 882256262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 249247540}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &882256264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 882256262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &882256265
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 882256262}
+  m_CullTransparentMesh: 1
 --- !u!1 &918975130
 GameObject:
   m_ObjectHideFlags: 0
@@ -2106,6 +2936,275 @@ Transform:
   - {fileID: 1534346491}
   m_Father: {fileID: 682825269}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1063520833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1063520834}
+  - component: {fileID: 1063520836}
+  - component: {fileID: 1063520835}
+  - component: {fileID: 1063520837}
+  m_Layer: 5
+  m_Name: WeaponLevelUp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1063520834
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063520833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1686196332}
+  - {fileID: 1630750910}
+  - {fileID: 36857842}
+  m_Father: {fileID: 1189105883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 800, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1063520835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063520833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1063520836
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063520833}
+  m_CullTransparentMesh: 1
+--- !u!114 &1063520837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063520833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10c834432811642abbd7aa3731722b3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameController: {fileID: 1227936012}
+  weaponController: {fileID: 682825268}
+  board: {fileID: 1063520833}
+  btnWeapon:
+  - {fileID: 407167088}
+  - {fileID: 463044345}
+  - {fileID: 1087212109}
+  txtStars:
+  - stars:
+    - {fileID: 750244414}
+    - {fileID: 2080994702}
+    - {fileID: 1833774110}
+  - stars:
+    - {fileID: 779781470}
+    - {fileID: 46778526}
+    - {fileID: 1434958381}
+  - stars:
+    - {fileID: 842924157}
+    - {fileID: 882256264}
+    - {fileID: 107593069}
+--- !u!1 &1063674509
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1063674510}
+  m_Layer: 5
+  m_Name: 'Level '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1063674510
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1063674509}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 779781469}
+  - {fileID: 46778525}
+  - {fileID: 1434958380}
+  m_Father: {fileID: 1630750910}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1087212107
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1087212108}
+  - component: {fileID: 1087212111}
+  - component: {fileID: 1087212110}
+  - component: {fileID: 1087212109}
+  m_Layer: 5
+  m_Name: Button (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1087212108
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087212107}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 36857842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1087212109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087212107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1087212110}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1087212110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087212107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1349035616, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1087212111
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087212107}
+  m_CullTransparentMesh: 1
 --- !u!1 &1125616872
 GameObject:
   m_ObjectHideFlags: 0
@@ -2145,6 +3244,85 @@ RectTransform:
   m_AnchoredPosition: {x: 428, y: -128}
   m_SizeDelta: {x: 428, y: 128}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &1167216998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1167216999}
+  - component: {fileID: 1167217001}
+  - component: {fileID: 1167217000}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1167216999
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167216998}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 36857842}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1167217000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167216998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u938C"
+--- !u!222 &1167217001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1167216998}
+  m_CullTransparentMesh: 1
 --- !u!1 &1168092007
 GameObject:
   m_ObjectHideFlags: 0
@@ -2255,6 +3433,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1931353884}
+  - {fileID: 1063520834}
   m_Father: {fileID: 1922671363}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2346,6 +3525,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mainCamera: {fileID: 519420031}
   playerController: {fileID: 386879982}
+  weaponController: {fileID: 682825268}
+  weaponBoard: {fileID: 1063520837}
+  expController: {fileID: 918975131}
   fieldController: {fileID: 961630575}
 --- !u!1 &1243791209
 GameObject:
@@ -2537,6 +3719,164 @@ MonoBehaviour:
   enemyController: {fileID: 365266726}
   prefab: {fileID: 3040417762749310419, guid: 3bbbe70dd5c7542a9b86212897b539e2, type: 3}
   parent: {fileID: 1509225102}
+--- !u!1 &1393814160
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1393814161}
+  - component: {fileID: 1393814163}
+  - component: {fileID: 1393814162}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1393814161
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393814160}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1686196332}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1393814162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393814160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u30B7\u30E7\u30C3\u30C8\u30AC\u30F3"
+--- !u!222 &1393814163
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393814160}
+  m_CullTransparentMesh: 1
+--- !u!1 &1434958379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1434958380}
+  - component: {fileID: 1434958382}
+  - component: {fileID: 1434958381}
+  m_Layer: 5
+  m_Name: Text_lv3 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1434958380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1434958379}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1063674510}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1434958381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1434958379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &1434958382
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1434958379}
+  m_CullTransparentMesh: 1
 --- !u!1 &1451293196
 GameObject:
   m_ObjectHideFlags: 0
@@ -2616,6 +3956,123 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1451293196}
   m_CullTransparentMesh: 1
+--- !u!1 &1465438632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1465438633}
+  - component: {fileID: 1465438635}
+  - component: {fileID: 1465438634}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1465438633
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465438632}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1630750910}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1465438634
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465438632}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u92E4"
+--- !u!222 &1465438635
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465438632}
+  m_CullTransparentMesh: 1
+--- !u!1 &1471812023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1471812024}
+  m_Layer: 5
+  m_Name: Level
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1471812024
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1471812023}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 750244413}
+  - {fileID: 2080994701}
+  - {fileID: 1833774109}
+  m_Father: {fileID: 1686196332}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -130}
+  m_SizeDelta: {x: 200, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1506865072
 GameObject:
   m_ObjectHideFlags: 0
@@ -3072,6 +4529,162 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1623504047}
   m_CullTransparentMesh: 1
+--- !u!1 &1630750909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1630750910}
+  - component: {fileID: 1630750912}
+  - component: {fileID: 1630750911}
+  m_Layer: 5
+  m_Name: Weapon2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1630750910
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630750909}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 463044344}
+  - {fileID: 1465438633}
+  - {fileID: 1063674510}
+  m_Father: {fileID: 1063520834}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1630750911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630750909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3764706, g: 0.61037344, b: 0.77254903, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1630750912
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1630750909}
+  m_CullTransparentMesh: 1
+--- !u!1 &1686196331
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1686196332}
+  - component: {fileID: 1686196334}
+  - component: {fileID: 1686196333}
+  m_Layer: 5
+  m_Name: Weapon1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1686196332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686196331}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 407167087}
+  - {fileID: 1393814161}
+  - {fileID: 1471812024}
+  m_Father: {fileID: 1063520834}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -240, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1686196333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686196331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.38616732, g: 0.7735849, b: 0.37584552, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1686196334
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686196331}
+  m_CullTransparentMesh: 1
 --- !u!1 &1714665915
 GameObject:
   m_ObjectHideFlags: 0
@@ -3340,6 +4953,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1827983651}
   m_CullTransparentMesh: 1
+--- !u!1 &1833774108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1833774109}
+  - component: {fileID: 1833774111}
+  - component: {fileID: 1833774110}
+  m_Layer: 5
+  m_Name: Text_lv3 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1833774109
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1833774108}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1471812024}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 60, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1833774110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1833774108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &1833774111
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1833774108}
+  m_CullTransparentMesh: 1
 --- !u!1 &1848950157
 GameObject:
   m_ObjectHideFlags: 0
@@ -3493,12 +5185,12 @@ GameObject:
   - component: {fileID: 1931353886}
   - component: {fileID: 1931353885}
   m_Layer: 5
-  m_Name: WeaponBase
+  m_Name: WeaponDebug
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1931353884
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3558,6 +5250,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1931353883}
+  m_CullTransparentMesh: 1
+--- !u!1 &2080994700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2080994701}
+  - component: {fileID: 2080994703}
+  - component: {fileID: 2080994702}
+  m_Layer: 5
+  m_Name: Text_lv2 (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2080994701
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080994700}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1471812024}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2080994702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080994700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u2606"
+--- !u!222 &2080994703
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2080994700}
   m_CullTransparentMesh: 1
 --- !u!1001 &2139378540
 PrefabInstance:

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -51,9 +51,17 @@ public class Bullet : MonoBehaviour
         // Enemy に当たったら消滅
         if (collision.tag == "Enemy")
         {
-            // Enemy が生きていたら消滅
-            if (collision.GetComponent<Enemy>().CurStatus == Enemy.Status.Alive)
+            Enemy enemy = collision.GetComponent<Enemy>();
+            // 対象のエネミーが未カウントの場合
+            if (!enemy.IsCounted)            
             {
+                // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
+                // Debug.Log(this.name + " Hit " + collision.name);
+
+                // カウント
+                enemy.IsCounted = true;
+
+                // 消滅
                 Destroy(this.gameObject);
                 // Debug.Log("Bullet Hit + " + collision.name);
             }

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -31,7 +31,9 @@ public class Bullet : MonoBehaviour
     private void Update()
     {
         if (!initialized) return;
-
+        // ポーズ中は無視
+        if (GameController.isPause) return;
+        
         // 移動
         Vector2 val = direction * (moveSpeed * Time.deltaTime);
         Vector3 pos = this.transform.localPosition + new Vector3(val.x, val.y, 0);

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -18,6 +18,10 @@ public class Enemy : BaseCharacter
     private Status status = Status.Init;
     public Status CurStatus { get => status; }
 
+    // 討伐カウントフラグ
+    private bool isCounted = false;
+    public bool IsCounted { get => isCounted; set => isCounted = value;}
+
     // 歩きパラメータ
     private const float MinInterval = 1.0f;
     private const float MaxInterval = 5.0f;

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -95,6 +95,9 @@ public class Enemy : BaseCharacter
     /// </summary>
     private void walk()
     {
+        // ポーズ中は無視
+        if (GameController.isPause) return;
+
         // 歩く
         this.transform.localPosition += new Vector3(walkInfo.course.x * WalkSpeed * Time.deltaTime, walkInfo.course.y * WalkSpeed * Time.deltaTime, 0);
         // タイマー更新

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -43,6 +43,8 @@ public class Enemy : BaseCharacter
     }
     private NockBack nockBack;
 
+    private ExpController expController;
+
     /// <summary>
     /// フレームワーク
     /// </summary>
@@ -70,8 +72,10 @@ public class Enemy : BaseCharacter
     /// <summary>
     /// 初期化
     /// </summary>
-    public void Init(Player player)
+    public void Init(Player player, ExpController expController)
     {
+        this.expController = expController;
+
         // 歩き情報を設定
         walkInfo.interval = Random.Range(MinInterval, MaxInterval);
         walkInfo.timer = walkInfo.interval;
@@ -149,7 +153,11 @@ public class Enemy : BaseCharacter
     public void OnAnimationEnd()
     {
         // 死亡アニメーションが終わったら消滅
-        if (status == Status.Dead) Destroy(this.gameObject);
+        if (status == Status.Dead) 
+        {
+            expController.Spawn(this.transform.position);
+            Destroy(this.gameObject);
+        }
     }
 
     // 死亡（GameObject 破棄）時に呼ばれるイベント

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 public class EnemyController : MonoBehaviour
 {
     [SerializeField] private PlayerController playerController;
+    [SerializeField] private ExpController expController;
 
     [SerializeField] private GameObject[] enemyPrefabs;
     [SerializeField] private GameObject parent;
@@ -32,7 +33,7 @@ public class EnemyController : MonoBehaviour
         const int MAX_BASE_ENEMYS  = 50;
         const float spawnRadiusMin = 5.0f;
         const float spawnRadiusMax = 10.0f;
-        const float spawnInterval  = 0.5f;
+        const float spawnInterval  = 1f;
         var waitTime = new WaitForSeconds(spawnInterval);
         while(true)
         {
@@ -107,7 +108,7 @@ public class EnemyController : MonoBehaviour
         enemies.Add(enemy.gameObject);
 
         // エネミーの向きを設定
-        enemy.GetComponent<Enemy>().Init(playerController.GetPlayer());
+        enemy.GetComponent<Enemy>().Init(playerController.GetPlayer(), expController);
 
         // エネミーの削除を監視し、削除されたらリストから削除
         enemy.GetComponent<Enemy>().OnDead.AddListener(() => Remove(enemy));
@@ -119,7 +120,7 @@ public class EnemyController : MonoBehaviour
     /// <param name="enemy">エネミーオブジェクト</param>
     public void Remove(GameObject enemy)
     {
-        enemies.Remove(enemy);
+        enemies.Remove(enemy);        
     }
 
     /// <summary>

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -39,20 +39,28 @@ public class EnemyController : MonoBehaviour
         var waitTime = new WaitForSeconds(spawnInterval);
         while(true)
         {
-            // 常に MAX体のエネミーが存在するように生成する
-            if(enemies.Count < MAX_BASE_ENEMYS)
-            {
-                // プレイヤー位置
-                Vector2 playerPos = playerController.GetPlayer().Position;
-                // 配置半径を決定
-                float r = UnityEngine.Random.Range(spawnRadiusMin, spawnRadiusMax);
-                // 配置角度を決定
-                float angle = UnityEngine.Random.Range(0, 360);
+            // ポーズ中は無視
+            if (!GameController.isPause)
+            {            
+                // 常に MAX体のエネミーが存在するように生成する
+                if(enemies.Count < MAX_BASE_ENEMYS)
+                {
+                    // プレイヤー位置
+                    Vector2 playerPos = playerController.GetPlayer().Position;
+                    // 配置半径を決定
+                    float r = UnityEngine.Random.Range(spawnRadiusMin, spawnRadiusMax);
+                    // 配置角度を決定
+                    float angle = UnityEngine.Random.Range(0, 360);
 
-                // 生成
-                spawn(playerPos, r, angle);
+                    // 生成
+                    spawn(playerPos, r, angle);
+                }
+                yield return waitTime;
             }
-            yield return waitTime;
+            else
+            {
+                yield return null;
+            }
         }
     }
 
@@ -65,29 +73,37 @@ public class EnemyController : MonoBehaviour
         int wave = 0;
         while(true)
         {
-            if(wave > 0)
-            {
-                // 生成数を wave から決定（最大100体）
-                float spawnNum = Mathf.Min(wave * 10, MaxSpawnNum);
-                // 等間隔に配置
-                float angleRange = 360 / spawnNum;
-                // プレイヤー位置
-                Vector2 playerPos = playerController.GetPlayer().Position;
-
-                // 生成
-                for(int i = 0; i < spawnNum; i++)
+            // ポーズ中は無視
+            if (!GameController.isPause)
+            {                        
+                if(wave > 0)
                 {
-                    // 配置半径を決定
-                    float r = spawnRadiusMax + UnityEngine.Random.Range(-1.0f, 1.0f);
-                    // 配置角度を決定
-                    float angle = angleRange * i;
+                    // 生成数を wave から決定（最大100体）
+                    float spawnNum = Mathf.Min(wave * 10, MaxSpawnNum);
+                    // 等間隔に配置
+                    float angleRange = 360 / spawnNum;
+                    // プレイヤー位置
+                    Vector2 playerPos = playerController.GetPlayer().Position;
 
                     // 生成
-                    spawn(playerPos, r, angle);
+                    for(int i = 0; i < spawnNum; i++)
+                    {
+                        // 配置半径を決定
+                        float r = spawnRadiusMax + UnityEngine.Random.Range(-1.0f, 1.0f);
+                        // 配置角度を決定
+                        float angle = angleRange * i;
+
+                        // 生成
+                        spawn(playerPos, r, angle);
+                    }
                 }
+                wave++;
+                yield return waitTime;
             }
-            wave++;
-            yield return waitTime;
+            else
+            {
+                yield return null;
+            }
         }
     }
 

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -16,6 +16,8 @@ public class EnemyController : MonoBehaviour
 
     private List<GameObject> enemies = new List<GameObject>();
 
+    private int no = 0;
+
     /// <summary>
     /// 起動時処理
     /// </summary>
@@ -31,7 +33,7 @@ public class EnemyController : MonoBehaviour
     private IEnumerator spawnBase()
     {
         const int MAX_BASE_ENEMYS  = 50;
-        const float spawnRadiusMin = 5.0f;
+        const float spawnRadiusMin = 8.0f;
         const float spawnRadiusMax = 10.0f;
         const float spawnInterval  = 1f;
         var waitTime = new WaitForSeconds(spawnInterval);
@@ -58,6 +60,7 @@ public class EnemyController : MonoBehaviour
     {
         const float spawnInterval = 10;
         const float MaxSpawnNum = 200;
+        const float spawnRadiusMax = 12.0f;
         var waitTime = new WaitForSeconds(spawnInterval);
         int wave = 0;
         while(true)
@@ -68,9 +71,6 @@ public class EnemyController : MonoBehaviour
                 float spawnNum = Mathf.Min(wave * 10, MaxSpawnNum);
                 // 等間隔に配置
                 float angleRange = 360 / spawnNum;
-                // 配置半径
-                float radiusBase = 7;
-
                 // プレイヤー位置
                 Vector2 playerPos = playerController.GetPlayer().Position;
 
@@ -78,7 +78,7 @@ public class EnemyController : MonoBehaviour
                 for(int i = 0; i < spawnNum; i++)
                 {
                     // 配置半径を決定
-                    float r = radiusBase + UnityEngine.Random.Range(-1.0f, 1.0f);
+                    float r = spawnRadiusMax + UnityEngine.Random.Range(-1.0f, 1.0f);
                     // 配置角度を決定
                     float angle = angleRange * i;
 
@@ -99,13 +99,17 @@ public class EnemyController : MonoBehaviour
     /// <param name="angle">配置角度</param>
     private void spawn(Vector2 playerPos, float r, float angle)
     {
+        no++;
+
         // プレイヤー位置を中心として、ランダムな位置に生成
         Vector2 pos = new Vector2(playerPos.x + r * Mathf.Cos(angle), playerPos.y + r * Mathf.Sin(angle));
 
         // ランダムなエネミーを生成
         GameObject enemy = Instantiate(enemyPrefabs[UnityEngine.Random.Range(0, enemyPrefabs.Length)], pos, Quaternion.identity);
         enemy.transform.parent = parent.transform;
+        enemy.name = "Enemy_" + no;
         enemies.Add(enemy.gameObject);
+
 
         // エネミーの向きを設定
         enemy.GetComponent<Enemy>().Init(playerController.GetPlayer(), expController);

--- a/Assets/Scripts/Exp.cs
+++ b/Assets/Scripts/Exp.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// 経験値オブジェクト
+/// </summary>
+public class Exp : MonoBehaviour
+{
+    private PlayerController playerController;
+    private const float MoveSpeed = 4f;
+    private bool isMoving = false;
+    public bool IsMoving { get => isMoving; }
+
+    /// <summary>
+    /// プレイヤーに向けて移動するトリガー
+    /// </summary>
+    /// <param name="playerController"></param>
+    public void Move(PlayerController playerController)
+    {
+        this.playerController = playerController;
+        isMoving = true;
+        StartCoroutine(move());
+    }
+
+    /// <summary>
+    /// プレイヤーに向けて移動する処理
+    /// </summary>
+    /// <returns>コルーチン</returns>
+    private IEnumerator move()
+    {
+        var elapsedTime = 0f;
+        var startPosition = transform.position;
+        while (elapsedTime < 1f)
+        {
+            var targetPosition = playerController.GetPosition();
+            elapsedTime += Time.deltaTime * MoveSpeed;
+            transform.position = Vector2.Lerp(startPosition, targetPosition, elapsedTime);
+            yield return null;
+        }
+        Destroy(gameObject);
+    }
+
+    /// <summary>
+    /// GameObject 破棄時に呼ばれるイベント
+    /// </summary>
+    /// <returns>イベント</returns>
+    public UnityEvent OnDeleted = new UnityEvent();
+    private void OnDestroy()
+    {
+        OnDeleted.Invoke();
+    }
+
+}

--- a/Assets/Scripts/Exp.cs.meta
+++ b/Assets/Scripts/Exp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 193bb340963074ddead5e1dafcbfc42a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -16,6 +16,11 @@ public class ExpController : MonoBehaviour
 
     private const float MoveThreshold = 2f;
 
+    // 経験値の取得数
+    private int expNum = 0;
+    public int GetExpNum { get { return expNum; } }
+    public void SubExpNum(int value) { expNum -= value; }
+
     /// <summary>
     /// exp オブジェクトを生成する
     /// </summary>
@@ -32,6 +37,7 @@ public class ExpController : MonoBehaviour
     /// <param name="exp">削除するオブジェクト</param>
     public void Remove(GameObject exp)
     {
+        expNum++;
         exps.Remove(exp);
     }
 

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 経験値管理
+/// </summary>
+public class ExpController : MonoBehaviour
+{
+    [SerializeField] private PlayerController playerController;
+
+    [SerializeField] private GameObject prefab;
+    [SerializeField] private GameObject parent;
+
+    private List<GameObject> exps = new List<GameObject>();
+
+    private const float MoveThreshold = 2f;
+
+    /// <summary>
+    /// exp オブジェクトを生成する
+    /// </summary>
+    /// <param name="pos">配置座標</param>
+    public void Spawn(Vector2 pos)
+    {
+        var exp = Instantiate(prefab, pos, Quaternion.identity, parent.transform);
+        exps.Add(exp);
+    }
+
+    /// <summary>
+    /// exp オブジェクトを削除する
+    /// </summary>
+    /// <param name="exp">削除するオブジェクト</param>
+    public void Remove(GameObject exp)
+    {
+        exps.Remove(exp);
+    }
+
+    /// <summary>
+    /// プレイヤーに近い exp オブジェクトをプレイヤーに向けて移動させる 
+    /// </summary>
+    private void Update()
+    {
+        Vector2 playerPos = playerController.GetPosition();
+        foreach (var exp in exps)
+        {
+            // 移動中でない場合
+            if (!exp.GetComponent<Exp>().IsMoving)
+            {
+                // プレイヤーとの距離を計算
+                float distance = Vector2.Distance(playerPos, exp.transform.position);
+                if (distance < MoveThreshold)
+                {
+                    exp.GetComponent<Exp>().Move(playerController);
+                    // 移動終了したらリストから削除
+                    exp.GetComponent<Exp>().OnDeleted.AddListener(() => Remove(exp));
+                }
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -46,6 +46,9 @@ public class ExpController : MonoBehaviour
     /// </summary>
     private void Update()
     {
+        // ポーズ中は無視
+        if (GameController.isPause) return;
+
         Vector2 playerPos = playerController.GetPosition();
         foreach (var exp in exps)
         {

--- a/Assets/Scripts/ExpController.cs.meta
+++ b/Assets/Scripts/ExpController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0874a2d80d17a43568af7ccb467cc4aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -12,6 +12,12 @@ public class GameController : MonoBehaviour
     [SerializeField] Camera mainCamera;
     // プレイヤー管理
     [SerializeField] PlayerController playerController;
+    // 武器管理
+    [SerializeField] WeaponController weaponController;
+    // 武器ボード
+    [SerializeField] WeaponBoard weaponBoard;
+    // 経験値管理
+    [SerializeField] ExpController expController;
     // フィールドワーク
     [SerializeField] FieldController fieldController;
 
@@ -24,19 +30,49 @@ public class GameController : MonoBehaviour
     // 長押し判定変数
     private float holdTime = HoldTime;
 
+    // 武器のレベルポイントが閾値を超えたら、武器レベルアップ（初期レベルは１で、９レベルまで）
+    private readonly int[] levelThreshold = { 0, 5, 10, 20, 30, 40, 60, 80, 100, 65535 };
+
+    // ポーズフラグ
+    public static bool isPause = false;
+    private int curLevelPoint = 0;
+
     /// <summary>
     /// フレームワーク
     /// </summary>
     void Update()
     {
-        // プレイヤー移動処理
-        if(onMove())
-        {
-            // カメラを追従させる
-            Vector3 pos = playerController.GetPosition();
-            pos.z = -1.0f;
-            mainCamera.gameObject.transform.localPosition = pos;
+        if(!isPause)
+        {        
+            // プレイヤー移動処理
+            if(onMove())
+            {
+                // カメラを追従させる
+                Vector3 pos = playerController.GetPosition();
+                pos.z = -1.0f;
+                mainCamera.gameObject.transform.localPosition = pos;
+            }
+
+            // 武器レベルアップ処理
+            if(expController.GetExpNum >= levelThreshold[weaponController.GetLevelPoint()])
+            {
+                // ポーズ
+                isPause = true;
+                // 現在のレベルポイントを保持
+                curLevelPoint = weaponController.GetLevelPoint();
+                // レベルアップボードを表示
+                weaponBoard.ShowBoard();
+            }
         }
+    }
+
+    // ポーズ解除
+    public void Resume()
+    {
+        // 経験値を保持したレベルポイント分減らす
+        expController.SubExpNum(levelThreshold[curLevelPoint]);
+        // ポーズ解除
+        isPause = false;
     }
 
     // 移動処理

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -20,7 +20,7 @@ public class Player : BaseCharacter
     private bool isWalking = false;
 
     // 移動速度の係数
-    private readonly float moveSpeed = 0.01f;
+    private readonly float moveSpeed = 2.5f;
 
     // フレームワーク
     private void Update()
@@ -53,7 +53,7 @@ public class Player : BaseCharacter
         isWalking = true;
 
         // 移動
-        Vector2 val = dir * moveSpeed;
+        Vector2 val = dir * (moveSpeed * Time.deltaTime);
         Vector3 pos = this.transform.localPosition + new Vector3(val.x, val.y, 0);
 
         // 移動範囲制限（FieldController で生成したフィールドの範囲）により、pos を制限

--- a/Assets/Scripts/Plow.cs
+++ b/Assets/Scripts/Plow.cs
@@ -57,19 +57,22 @@ public class Plow : MonoBehaviour
 
        float t = 0f;
         while (t <= 1 && isAlive) {
-            float Vx = 2 * (1f - t) * t * p1.x + Mathf.Pow (t, 2) * p2.x + p0.x;
-            float Vy = 2 * (1f - t) * t * p1.y + Mathf.Pow (t, 2) * p2.y + p0.y;
-            transform.position = new Vector3 (Vx, Vy, 0);
-
-            t += 1 / distance / speed * Time.deltaTime;
-
-            // t が 0.4 から 0.6 の間に、徐々に180°回転させる
-            if (t > 0.4f && t < 0.6f)
+            // ポーズ中は無視
+            if (!GameController.isPause)
             {
-                float angle = Mathf.Lerp(0, courseGoal[course], (t - 0.4f) / 0.2f);
-                transform.rotation = Quaternion.Euler(0, 0, angle);
-            }
+                float Vx = 2 * (1f - t) * t * p1.x + Mathf.Pow (t, 2) * p2.x + p0.x;
+                float Vy = 2 * (1f - t) * t * p1.y + Mathf.Pow (t, 2) * p2.y + p0.y;
+                transform.position = new Vector3 (Vx, Vy, 0);
 
+                t += 1 / distance / speed * Time.deltaTime;
+
+                // t が 0.4 から 0.6 の間に、徐々に180°回転させる
+                if (t > 0.4f && t < 0.6f)
+                {
+                    float angle = Mathf.Lerp(0, courseGoal[course], (t - 0.4f) / 0.2f);
+                    transform.rotation = Quaternion.Euler(0, 0, angle);
+                }
+            }
             yield return null;
         }
 

--- a/Assets/Scripts/Plow.cs
+++ b/Assets/Scripts/Plow.cs
@@ -22,7 +22,7 @@ public class Plow : MonoBehaviour
     // 生存フラグ
     private bool isAlive = true;
     // ヒット数
-    private int hitCount = 3;
+    private int hitCount = 5;
 
     // 左右向き
     private int course = 0; // 0:右、1:左
@@ -85,9 +85,20 @@ public class Plow : MonoBehaviour
         // Enemy に当たったら消滅
         if (collision.tag == "Enemy")
         {
-            // ヒット数を減らし、ヒット数が０になったら生存フラグを降ろす
-            hitCount--;
-            if (hitCount <= 0) isAlive = false;
+            Enemy enemy = collision.GetComponent<Enemy>();
+            // 対象のエネミーが未カウントの場合
+            if (!enemy.IsCounted)            
+            {
+                // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
+                // Debug.Log(this.name + " Hit " + collision.name);
+
+                // カウント
+                enemy.IsCounted = true;
+
+                // ヒット数を減らし、ヒット数が０になったら生存フラグを降ろす
+                hitCount--;
+                if (hitCount <= 0) isAlive = false;
+            }
         }
     }
 

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -48,6 +48,9 @@ public class Sickle : MonoBehaviour
     /// </summary>
     void Update()
     {
+        // ポーズ中は無視
+        if (GameController.isPause) return;
+
         // 角度（公転）を増加
         rotateAngle -= RotateSpeed * Time.deltaTime;
         // 角度（自転）を増加

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -79,8 +79,18 @@ public class Sickle : MonoBehaviour
         // Enemy に当たったら消滅
         if (collision.tag == "Enemy")
         {
-            // 親オブジェクトへ通知
-            OnHit.Invoke();
+            Enemy enemy = collision.GetComponent<Enemy>();
+            // 対象のエネミーが未カウントの場合
+            if (!enemy.IsCounted)
+            {
+                // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
+                // Debug.Log(this.name + " Hit " + collision.name);
+
+                // カウント
+                enemy.IsCounted = true;
+                // 親オブジェクトへ通知
+                OnHit.Invoke();
+            }
         }
     }
 

--- a/Assets/Scripts/WeaponBase.cs
+++ b/Assets/Scripts/WeaponBase.cs
@@ -22,10 +22,22 @@ public class WeaponBase : MonoBehaviour
     // レベル取得
     public int GetLevel() { return level; }
     // レベルアップ
-    public void LevelUp()
+    public bool LevelUp()
     {
-        // レベルアップ
-        level = Mathf.Min(level + 1, WeaponController.maxLevel - 1);
+        // 非アクティブの場合はアクティブする
+        if(!isActive)
+        {
+            Activate();
+            return true;
+        }
+
+        // レベルアップ（レベルアップした場合はtrueを返す）
+        if(level < WeaponController.maxLevel - 1)
+        {
+            level++;
+            return true;
+        }
+        return false;
     }
     // レベルダウン
     public void LevelDown()
@@ -43,6 +55,16 @@ public class WeaponBase : MonoBehaviour
     public bool IsActive() { return isActive; }
     // アクティブ化
     public void Activate() { isActive = true; }
+
+    /// <summary>
+    /// レベルに応じたポイントの取得（表示用）
+    /// </summary>
+    /// <returns>レベルポイント</returns>
+    public int GetLevelPoint()
+    {
+        if(!isActive) return 0;
+        else return level + 1;
+    }
 
 
 }

--- a/Assets/Scripts/WeaponBoard.cs
+++ b/Assets/Scripts/WeaponBoard.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// 武器ボード
+/// </summary>
+public class WeaponBoard : MonoBehaviour
+{
+    // ゲーム管理
+    [SerializeField] private GameController gameController;
+    // 武器管理
+    [SerializeField] private WeaponController weaponController;
+
+    // ボード（オブジェクト）
+    [SerializeField] private GameObject board;
+    // ボタン
+    [SerializeField] private Button[] btnWeapon;
+    // 星（text）
+    [SerializeField] private StarText[] txtStars;
+    [System.Serializable]
+    private class StarText
+    {
+        public Text[] stars;
+    }
+
+    /// <summary>
+    /// 起動時処理
+    /// </summary>
+    void Start()
+    {
+        // ボタン操作（リスナー）
+        for(int i=0; i<btnWeapon.Length; i++)
+        {
+            int index = i;
+            btnWeapon[i].onClick.AddListener(() => 
+            {
+                if(weaponController.LevelUp((WeaponController.WeaponType)index))
+                {
+                    // ボードを非表示
+                    HideBoard();
+                    // ポーズ解除
+                    gameController.Resume();
+                }
+            });
+        }
+        // ボードを非表示
+        HideBoard();
+    }
+
+    /// <summary>
+    /// ボード表示
+    /// </summary>
+    public void ShowBoard()
+    {
+        // ボードを表示
+        board.SetActive(true);
+
+        // 各武器レベルを設定
+        for(int type=0 ; type<(int)WeaponController.WeaponType.Num ; type++)
+        {
+            int lp = weaponController.GetLevelPointForWeapon((WeaponController.WeaponType)type);
+            for(int i=0; i<txtStars[type].stars.Length; i++)
+            {
+                txtStars[type].stars[i].text = (lp > i) ? "★" : "☆";
+            }
+        }
+    }
+
+    /// <summary>
+    /// ボード非表示
+    /// </summary>
+    private void HideBoard()
+    {
+        // ボードを非表示
+        board.SetActive(false);
+    }
+
+}

--- a/Assets/Scripts/WeaponBoard.cs.meta
+++ b/Assets/Scripts/WeaponBoard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10c834432811642abbd7aa3731722b3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WeaponController.cs
+++ b/Assets/Scripts/WeaponController.cs
@@ -14,7 +14,7 @@ public class WeaponController : MonoBehaviour
         Weapon_1,   // 武器１（デフォルト武器）
         Weapon_2,   // 武器２
         Weapon_3,   // 武器３
-        Weapon_Num  // 武器数
+        Num         // 武器数
     }
 
     // 武器インターフェース
@@ -25,7 +25,7 @@ public class WeaponController : MonoBehaviour
         public Button btnUp;    // レベルアップボタン
         public Text txtLevel;   // レベル表示テキスト
     }
-    [SerializeField] private WeaponInterface[] weaponInterface = new WeaponInterface[(int)WeaponType.Weapon_Num];
+    [SerializeField] private WeaponInterface[] weaponInterface = new WeaponInterface[(int)WeaponType.Num];
 
     // 最大レベル
     public static readonly int maxLevel = 3;    
@@ -48,7 +48,8 @@ public class WeaponController : MonoBehaviour
         // 武器１のボタンイベント設定
         weaponInterface[(int)WeaponType.Weapon_1].btnDown.onClick.AddListener(() => { weapon_1.LevelDown(); setWeapon1Level(); } );
         weaponInterface[(int)WeaponType.Weapon_1].btnUp.onClick.AddListener(() => { weapon_1.LevelUp(); setWeapon1Level(); } );
-        setWeapon1Level();  // 初期レベル
+        weapon_1.Activate();    // アクティブ化
+        setWeapon1Level();      // 初期レベル
 
         // 武器２のボタンイベント設定
         weaponInterface[(int)WeaponType.Weapon_2].btnDown.onClick.AddListener(() =>
@@ -97,19 +98,68 @@ public class WeaponController : MonoBehaviour
     /// </summary>
     private void setWeapon1Level()
     {
-        weaponInterface[(int)WeaponType.Weapon_1].txtLevel.text = (weapon_1.GetLevel() + 1).ToString();  // 表示はプラス１する
+        weaponInterface[(int)WeaponType.Weapon_1].txtLevel.text = (weapon_1.GetLevelPoint()).ToString();  // 表示はプラス１する
     }
 
     // 武器２のレベル表示
     private void setWeapon2Level()
     {
-        weaponInterface[(int)WeaponType.Weapon_2].txtLevel.text = (weapon_2.GetLevel() + 1).ToString();  // 表示はプラス１する
+        weaponInterface[(int)WeaponType.Weapon_2].txtLevel.text = (weapon_2.GetLevelPoint()).ToString();  // 表示はプラス１する
     }
 
     // 武器３のレベル表示
     private void setWeapon3Level()
     {
-        weaponInterface[(int)WeaponType.Weapon_3].txtLevel.text = (weapon_3.GetLevel() + 1).ToString();  // 表示はプラス１する
+        weaponInterface[(int)WeaponType.Weapon_3].txtLevel.text = (weapon_3.GetLevelPoint()).ToString();  // 表示はプラス１する
+    }
+
+    /// <summary>
+    /// 全武器のレベルポイント取得
+    /// </summary>
+    /// <returns>レベルポイント</returns>
+    public int GetLevelPoint() { return weapon_1.GetLevelPoint() + weapon_2.GetLevelPoint() + weapon_3.GetLevelPoint();}
+
+    /// <summary>
+    /// 武器タイプごとのレベルポイント取得
+    /// </summary>
+    /// <param name="type">武器タイプ</param>
+    /// <returns>レベルポイント</returns>
+    public int GetLevelPointForWeapon(WeaponType type)
+    {
+        switch (type)
+        {
+            case WeaponType.Weapon_1:   return weapon_1.GetLevelPoint();
+            case WeaponType.Weapon_2:   return weapon_2.GetLevelPoint();
+            case WeaponType.Weapon_3:   return weapon_3.GetLevelPoint();
+        }
+        return 0;        
+    }
+
+    /// <summary>
+    /// レベルアップ処理
+    /// </summary>
+    /// <param name="type">武器タイプ</param>
+    /// <returns>レベルアップした場合は true を返す</returns>
+    public bool LevelUp(WeaponType type)
+    {
+        bool isLevelUp = false;
+        switch (type)
+        {
+            case WeaponType.Weapon_1:
+                isLevelUp = weapon_1.LevelUp();
+                setWeapon1Level();
+                break;
+            case WeaponType.Weapon_2:
+                isLevelUp = weapon_2.LevelUp();
+                setWeapon2Level();
+                break;
+            case WeaponType.Weapon_3:
+                isLevelUp = weapon_3.LevelUp();
+                weapon_3.CreateAndInitialize(playerController.GetPlayer());
+                setWeapon3Level();
+                break;
+        }
+        return isLevelUp;        
     }
 
 }

--- a/Assets/Scripts/Weapon_1.cs
+++ b/Assets/Scripts/Weapon_1.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 public class Weapon_1 : WeaponBase
 {
     // 弾の発射間隔（３レベル）
-    private readonly float[] interval = { 1.5f, 1.25f, 1.0f };
+    private readonly float[] interval = { 2.0f, 1.75f, 1.5f };
     // 弾の射程（３レベル）
     private readonly float[] range = { 4.0f, 6.0f, 8.0f };
     // 同時発射数（３レベル）

--- a/Assets/Scripts/Weapon_1.cs
+++ b/Assets/Scripts/Weapon_1.cs
@@ -32,7 +32,9 @@ public class Weapon_1 : WeaponBase
     {
         // アクティブでない場合は処理しない
         if (!isActive) return;
-
+        // ポーズ中は無視
+        if (GameController.isPause) return;
+        
         // インターバルタイマー更新
         intervalTimer += Time.deltaTime;
         // インターバルチェック

--- a/Assets/Scripts/Weapon_2.cs
+++ b/Assets/Scripts/Weapon_2.cs
@@ -27,6 +27,8 @@ public class Weapon_2 : WeaponBase
     {
         // アクティブでない場合は処理しない
         if (!isActive) return;
+        // ポーズ中は無視
+        if (GameController.isPause) return;
 
         // インターバルタイマー更新
         intervalTimer += Time.deltaTime;
@@ -50,27 +52,36 @@ public class Weapon_2 : WeaponBase
         int num = simultaneous[GetLevel()];
         while(num > 0)
         {
-            // 発射数を減らす
-            num--;
+            // ポーズ中でなければ
+            if (!GameController.isPause)
+            {
+                // 発射数を減らす
+                num--;
 
-            // 始点（プレイヤー位置）
-            Vector3 p0 = playerController.GetPosition();
-            // 頂点（相対座標）
-            float c = UnityEngine.Random.Range(0, 2) == 0 ? -1 : 1;                     // 向き（左右）
-            float w = UnityEngine.Random.Range(minWidth, maxWidth[GetLevel()]) * c;     // 幅
-            float h = height + UnityEngine.Random.Range(0, rndHeight);                  // 高さ
-            Vector3 p1 = new Vector3((w / 2f), h, 0);
-            // 終点（相対座標）
-            Vector3 p2 = new Vector3( w, endHeight, 0);
+                // 始点（プレイヤー位置）
+                Vector3 p0 = playerController.GetPosition();
+                // 頂点（相対座標）
+                float c = UnityEngine.Random.Range(0, 2) == 0 ? -1 : 1;                     // 向き（左右）
+                float w = UnityEngine.Random.Range(minWidth, maxWidth[GetLevel()]) * c;     // 幅
+                float h = height + UnityEngine.Random.Range(0, rndHeight);                  // 高さ
+                Vector3 p1 = new Vector3((w / 2f), h, 0);
+                // 終点（相対座標）
+                Vector3 p2 = new Vector3( w, endHeight, 0);
 
-            // 生成
-            GameObject obj = Instantiate(prefab, parent);
+                // 生成
+                GameObject obj = Instantiate(prefab, parent);
 
-            // 初期化
-            obj.GetComponent<Plow>().Initialize(p0, p1, p2);
+                // 初期化
+                obj.GetComponent<Plow>().Initialize(p0, p1, p2);
 
-            // インターバル
-            yield return new WaitForSeconds(0.8f);
+                // インターバル
+                yield return new WaitForSeconds(0.8f);
+            }
+            else
+            {
+                // ポーズ中は待機
+                yield return null;
+            }
         }
     }
 


### PR DESCRIPTION
## 経験値制御を追加
- エネミー死亡時に経験値を生成
- プレイヤーが一定距離内に来たら、プレイヤーに吸い込まれる

## 武器レベルアップボード対応
- 武器レベルアップ用のボードを作成
- 総武器レベルに応じた討伐数によりレベルアップ可能
- ボード表示時はポーズ状態

## 細かな調整
- プレイヤーの移動速度を調整
- エネミー生成処理を調整
- 武器３の不具合を修正
- コリジョン判定の順序問題を調整（討伐カウント）