### PR TITLE
エネミーと武器の見直し

### DIFF
--- a/Assets/Animations/AC_enemy_0.controller
+++ b/Assets/Animations/AC_enemy_0.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-9018681522850671120
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: status
+    m_EventTreshold: 1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3224820283492065302}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -47,7 +72,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: status
+    m_EventTreshold: 3
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 5227992839476743573}
   m_Solo: 0
@@ -101,6 +129,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1808020088855761696}
+  - {fileID: -9018681522850671120}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Animations/AC_enemy_1.controller
+++ b/Assets/Animations/AC_enemy_1.controller
@@ -12,6 +12,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 967037107738208800}
+  - {fileID: 8109660434585373847}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -62,7 +63,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: status
+    m_EventTreshold: 3
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 1346045142926947027}
   m_Solo: 0
@@ -156,6 +160,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: -150, y: -80, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 8839176375226125154}
+--- !u!1101 &8109660434585373847
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 6
+    m_ConditionEvent: status
+    m_EventTreshold: 1
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8839176375226125154}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &8839176375226125154
 AnimatorState:
   serializedVersion: 6

--- a/Assets/Prefabs/enemy_1.prefab
+++ b/Assets/Prefabs/enemy_1.prefab
@@ -52,6 +52,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -89,7 +92,7 @@ SpriteRenderer:
   m_SpriteSortPoint: 0
 --- !u!95 &8293989762275847391
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -103,6 +106,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -116,6 +120,7 @@ CircleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2194842702961310431}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -139,9 +144,9 @@ CircleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
   m_Radius: 0.5
 --- !u!114 &3943280836880103590
 MonoBehaviour:
@@ -155,3 +160,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b41bc1532fe54b759e5b039d1d2dbaf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  hp: 20
+  OnDead:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Scripts/Bullet.cs
+++ b/Assets/Scripts/Bullet.cs
@@ -54,19 +54,18 @@ public class Bullet : MonoBehaviour
         if (collision.tag == "Enemy")
         {
             Enemy enemy = collision.GetComponent<Enemy>();
-            // 対象のエネミーが未カウントの場合
-            if (!enemy.IsCounted)            
+            // 対象のエネミーがアクティブ時のみ
+            if (enemy.CurStatus == Enemy.Status.Alive)
             {
-                // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
-                // Debug.Log(this.name + " Hit " + collision.name);
-
-                // カウント
-                enemy.IsCounted = true;
-
                 // 消滅
                 Destroy(this.gameObject);
-                // Debug.Log("Bullet Hit + " + collision.name);
             }
+            /*
+            else
+            {
+                Debug.Log("Bullet Hit + " + collision.name + " (Already counted)");
+            }
+            */
         }
     }
 

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -145,20 +145,22 @@ public class Enemy : BaseCharacter
     /// <param name="collision">相手側の情報が格納される</param>
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        // 死んでいる場合は無視
-        if (status == Status.Init || status == Status.Dead) return;
-
-        // Weapon に当たったらダメージ
-        if (collision.tag == "Weapon")
+        // status が Alive の場合のみ
+        if (status == Status.Alive) 
         {
-            // Debug.Log("Enemy Hit : " + collision.name);
+            // Weapon に当たったらダメージ
+            if (collision.tag == "Weapon")
+            {
+                // アニメーションの status を変更
+                setStatus(Status.Hit);
 
-            // アニメーションの status を変更
-            setStatus(Status.Hit);
+                // 武器と反対方向へノックバック
+                Vector2 dir = (this.transform.localPosition - collision.transform.localPosition).normalized;
+                setNockBack(dir);
 
-            // 武器と反対方向へノックバック
-            Vector2 dir = (this.transform.localPosition - collision.transform.localPosition).normalized;
-            setNockBack(dir);
+                //武器の名称
+                Debug.Log("Weapon Hit : " + collision.name);
+            }
         }
     }
 

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -121,7 +121,8 @@ public class EnemyController : MonoBehaviour
         Vector2 pos = new Vector2(playerPos.x + r * Mathf.Cos(angle), playerPos.y + r * Mathf.Sin(angle));
 
         // ランダムなエネミーを生成
-        GameObject enemy = Instantiate(enemyPrefabs[UnityEngine.Random.Range(0, enemyPrefabs.Length)], pos, Quaternion.identity);
+        int enemyNo = UnityEngine.Random.Range(0, enemyPrefabs.Length);
+        GameObject enemy = Instantiate(enemyPrefabs[enemyNo], pos, Quaternion.identity);
         enemy.transform.parent = parent.transform;
         enemy.name = "Enemy_" + no;
         enemies.Add(enemy.gameObject);

--- a/Assets/Scripts/Plow.cs
+++ b/Assets/Scripts/Plow.cs
@@ -90,14 +90,11 @@ public class Plow : MonoBehaviour
         if (collision.tag == "Enemy")
         {
             Enemy enemy = collision.GetComponent<Enemy>();
-            // 対象のエネミーが未カウントの場合
-            if (!enemy.IsCounted)            
+            // 対象のエネミーが生存
+            if (enemy.CurStatus == Enemy.Status.Alive)
             {
                 // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
                 // Debug.Log(this.name + " Hit " + collision.name);
-
-                // カウント
-                enemy.IsCounted = true;
 
                 // ヒット数を減らし、ヒット数が０になったら生存フラグを降ろす
                 hitCount--;

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -64,26 +64,4 @@ public class Sickle : MonoBehaviour
         transform.rotation = Quaternion.Euler(0.0f, 0.0f, spinAngle);
     }
 
-    /// <summary>
-    /// コライダーが当たったら最初に呼ばれる
-    /// </summary>
-    /// <param name="collision">相手側の情報が格納される</param>
-    private void OnTriggerEnter2D(Collider2D collision)
-    {
-        // Enemy に当たったら消滅
-        if (collision.tag == "Enemy")
-        {
-            Enemy enemy = collision.GetComponent<Enemy>();
-            // 対象のエネミーが未カウントの場合
-            if (!enemy.IsCounted)
-            {
-                // デバッグログ（自オブジェクトとヒットしたオブジェクトの名称）
-                // Debug.Log(this.name + " Hit " + collision.name);
-
-                // カウント
-                enemy.IsCounted = true;
-            }
-        }
-    }
-
 }

--- a/Assets/Scripts/Sickle.cs
+++ b/Assets/Scripts/Sickle.cs
@@ -1,23 +1,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
 
 /// <summary>
 /// 鎌（農具）
 /// </summary>
 public class Sickle : MonoBehaviour
 {
-/*
-    void Start()
-    {
-        // 初期化
-        Initialize(0.0f);
-    }
-*/
-
     // 半径
-    public const float Radius = 4.0f;
+    public const float Radius = 3.5f;
     // 回転速度（秒間）
     private const float RotateSpeed = 180f;
     // 自転速度（秒間）
@@ -91,13 +82,8 @@ public class Sickle : MonoBehaviour
 
                 // カウント
                 enemy.IsCounted = true;
-                // 親オブジェクトへ通知
-                OnHit.Invoke();
             }
         }
     }
-
-    // ヒット時に呼ばれるイベント
-    public UnityEvent OnHit = new UnityEvent();
 
 }

--- a/Assets/Scripts/Weapon_3.cs
+++ b/Assets/Scripts/Weapon_3.cs
@@ -7,13 +7,17 @@ using UnityEngine;
 /// </summary>
 public class Weapon_3 : WeaponBase
 {
+    private enum Mode { None, Active, Wait };
+    private Mode mode = Mode.None;
+
     // 同時出現数（３レベル）
     private readonly int[] simultaneous = { 1, 2, 3 };
     private readonly float[] relativeAngles = { 0.0f, 180.0f, 120.0f };
-    private readonly int[] hitMaxes = { 5, 20, 40 };
-    private int curHit = 0;
-    private readonly int waitTime = 5;
-    private bool isCoolTime = false;
+
+    // 発生時間と待機時間
+    private readonly int ActiveTime = 10;
+    private readonly int WaitTime = 5;
+    private float curTime = 0.0f;
 
     // 生成済みの鎌
     private List<GameObject> sickles = new List<GameObject>();
@@ -29,13 +33,6 @@ public class Weapon_3 : WeaponBase
         int existNum = sickles.Count;
         // 生成する鎌の数を取得
         int num = simultaneous[GetLevel()];
-
-        // クールタイム中なら解除する
-        if(isCoolTime)
-        {
-            isCoolTime = false;
-            StopCoroutine(WaitActive());
-        }
 
         for(int i=0 ; i<num ; i++)
         {
@@ -55,10 +52,7 @@ public class Weapon_3 : WeaponBase
             {
                 sickle = Instantiate(prefab, parent);
                 sickles.Add(sickle);
-                sickle.name = "Sickle_" + i;
-
-                // 当たり判定を監視し、
-                sickle.GetComponent<Sickle>().OnHit.AddListener(() => Hit(sickle));                
+                sickle.name = "Sickle_" + i;      
             }
             // 初期化
             rot = relativeAngles[GetLevel()] * i;
@@ -71,51 +65,60 @@ public class Weapon_3 : WeaponBase
             Destroy(sickles[i]);
             sickles.RemoveAt(i);
         }
+
+        // アクティブから再生
+        mode    = Mode.Wait;
+        curTime = WaitTime;
+    }
+
+    private void Update()
+    {
+        if(!isActive)
+        {
+            mode = Mode.None;
+            return;
+        }
+        if(mode == Mode.None) return;
+        if(GameController.isPause) return;
+
+        curTime += Time.deltaTime;
+        float time = (mode == Mode.Active) ? ActiveTime : WaitTime;
+        if(curTime >= time)
+        {
+            if(mode == Mode.Active)
+            {
+                toWait();
+                mode = Mode.Wait;
+            }
+            else
+            {
+                toActive();
+                mode = Mode.Active;
+            }
+            curTime = 0.0f;
+        }
+
     }
 
     /// <summary>
-    /// 当たり判定が発生したら呼ばれる
+    /// アクティブ時間
     /// </summary>
-    /// <param name="sickle"></param>
-    private void Hit(GameObject sickle)
+    private void toActive()
     {
-        if(isCoolTime) return;
-
-        curHit++;
-        // デバッグログ（名称・ヒット数）
-        // Debug.Log(sickle.name + " Hit: " + curHit);
-
-        if(curHit >= hitMaxes[GetLevel()])
+        for(int i=0 ; i<sickles.Count ; i++)
         {
-            // デバッグログ（レベル・ヒット数・最大ヒット数）
-            // Debug.Log("Level: " + GetLevel() + " Hit: " + curHit + " Max: " + hitMaxes[GetLevel()]);
-
-            // ヒット数をリセット
-            curHit = 0;
-            // 武器を非アクティブにする
-            for(int i=0 ; i<sickles.Count ; i++)
-            {
-                sickles[i].SetActive(false);
-            }
-
-            // 待機時間後に再度アクティブにする
-            isCoolTime = true;
-            StartCoroutine(WaitActive());
+            sickles[i].SetActive(true);
         }
     }
 
     /// <summary>
     /// 使用不可時間
     /// </summary>
-    /// <returns>こルーチン</returns>
-    private IEnumerator WaitActive()
+    private void toWait()
     {
-        yield return new WaitForSeconds(waitTime);
-
         for(int i=0 ; i<sickles.Count ; i++)
         {
-            sickles[i].SetActive(true);
+            sickles[i].SetActive(false);
         }
-        isCoolTime = false;
     }
 }

--- a/Assets/Settings.meta
+++ b/Assets/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f02832c3a36bd474fa635149ba0ab3e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Build Profiles.meta
+++ b/Assets/Settings/Build Profiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e4fc5c752e7b470da162320fa17c2e5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Build Profiles/New Windows Profile.asset
+++ b/Assets/Settings/Build Profiles/New Windows Profile.asset
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: New Windows Profile
+  m_EditorClassIdentifier: 
+  m_AssetVersion: 1
+  m_BuildTarget: 19
+  m_Subtarget: 2
+  m_PlatformId: 4e3c793746204150860bf175a9a41a05
+  m_PlatformBuildProfile:
+    rid: 334479751892434944
+  m_OverrideGlobalSceneList: 1
+  m_Scenes:
+  - m_enabled: 1
+    m_path: Assets/Scenes/Title.unity
+  - m_enabled: 1
+    m_path: Assets/Scenes/Game.unity
+  m_ScriptingDefines: []
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 334479751892434944
+      type: {class: WindowsPlatformSettings, ns: UnityEditor.WindowsStandalone, asm: UnityEditor.WindowsStandalone.Extensions}
+      data:
+        m_Development: 0
+        m_ConnectProfiler: 0
+        m_BuildWithDeepProfilingSupport: 0
+        m_AllowDebugging: 0
+        m_WaitForManagedDebugger: 0
+        m_ManagedDebuggerFixedPort: 0
+        m_ExplicitNullChecks: 0
+        m_ExplicitDivideByZeroChecks: 0
+        m_ExplicitArrayBoundsChecks: 0
+        m_CompressionType: 0
+        m_InstallInBuildFolder: 0
+        m_WindowsBuildAndRunDeployTarget: 0
+        m_Architecture: 0
+        m_CreateSolution: 0
+        m_CopyPDBFiles: 0
+        m_WindowsDevicePortalAddress: 
+        m_WindowsDevicePortalUsername: 

--- a/Assets/Settings/Build Profiles/New Windows Profile.asset.meta
+++ b/Assets/Settings/Build Profiles/New Windows Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e1093da227ea469294ebc1800eb819e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### エネミー見直し
* HP の概念を追加
・enemy1 : HP10, enemy2 : HP20
・攻撃1回で 10ダメージが入る状態（一旦、固定値）
・ダメージアニメ後に HP が残る場合は、再度歩きモーションに切り替え
・HP が０の場合は死亡アニメ（今までと変わらず）

### 武器見直し
* 全武器のコリジョン発生時の処理を見直し
* 鎌
　・範囲を調整
　・一定時間攻撃するよう調整
　・時間制御をコルーチンから Update に変更（ポーズ時対応のため）
* 鎌、弾
　・エネミーの状態判定を調整