### PR TITLE
経験値の種類を増やす

### DIFF
--- a/Assets/Prefabs/Exp_L.prefab
+++ b/Assets/Prefabs/Exp_L.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4514414920102664908
+--- !u!1 &3589011983972985449
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1700546527121884637}
-  - component: {fileID: 8419474527371356181}
-  - component: {fileID: -5788174390138871516}
+  - component: {fileID: 2814526223909613071}
+  - component: {fileID: 1114317251447487751}
+  - component: {fileID: 4425348968814127556}
   m_Layer: 0
-  m_Name: Mag
+  m_Name: Exp_L
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1700546527121884637
+--- !u!4 &2814526223909613071
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 3589011983972985449}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.9}
+  m_LocalPosition: {x: 0, y: 0, z: 0.8}
   m_LocalScale: {x: 0.75, y: 0.75, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8419474527371356181
+--- !u!212 &1114317251447487751
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 3589011983972985449}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -77,30 +77,30 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 1997828774, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Sprite: {fileID: -1997803578, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.6666667, y: 0.6111111}
+  m_Size: {x: 0.5555556, y: 0.6111111}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &-5788174390138871516
+--- !u!114 &4425348968814127556
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 3589011983972985449}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 193bb340963074ddead5e1dafcbfc42a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  type: 4
+  type: 2
   OnDeleted:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/Exp_L.prefab.meta
+++ b/Assets/Prefabs/Exp_L.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eae9ac97ffa2e427cbdf830a65c1ede3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Exp_M.prefab
+++ b/Assets/Prefabs/Exp_M.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &11022837396415520
+--- !u!1 &3720869205308823430
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5184037780259149511}
-  - component: {fileID: 2547597275840355670}
-  - component: {fileID: 5700797992528639974}
+  - component: {fileID: 914423745113370820}
+  - component: {fileID: 1104911518141164064}
+  - component: {fileID: 8849501849164160134}
   m_Layer: 0
-  m_Name: exp
+  m_Name: Exp_M
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5184037780259149511
+--- !u!4 &914423745113370820
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11022837396415520}
+  m_GameObject: {fileID: 3720869205308823430}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.8}
   m_LocalScale: {x: 0.75, y: 0.75, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2547597275840355670
+--- !u!212 &1104911518141164064
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11022837396415520}
+  m_GameObject: {fileID: 3720869205308823430}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -50,6 +50,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -74,7 +77,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -1997803578, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Sprite: {fileID: 1807624531, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -85,18 +88,19 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &5700797992528639974
+--- !u!114 &8849501849164160134
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11022837396415520}
+  m_GameObject: {fileID: 3720869205308823430}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 193bb340963074ddead5e1dafcbfc42a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 1
   OnDeleted:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/Exp_M.prefab.meta
+++ b/Assets/Prefabs/Exp_M.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 022891dd1112d45a58b6f056786abeb6
+guid: c6c4043fcffa9463ba57921278648389
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Prefabs/Exp_S.prefab
+++ b/Assets/Prefabs/Exp_S.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4514414920102664908
+--- !u!1 &815894738947505585
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,38 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1700546527121884637}
-  - component: {fileID: 8419474527371356181}
-  - component: {fileID: -5788174390138871516}
+  - component: {fileID: 8027667493013258251}
+  - component: {fileID: 7985701074911559247}
+  - component: {fileID: 7152277760729955073}
   m_Layer: 0
-  m_Name: Mag
+  m_Name: Exp_S
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1700546527121884637
+--- !u!4 &8027667493013258251
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 815894738947505585}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.9}
+  m_LocalPosition: {x: 0, y: 0, z: 0.8}
   m_LocalScale: {x: 0.75, y: 0.75, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8419474527371356181
+--- !u!212 &7985701074911559247
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 815894738947505585}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -77,30 +77,30 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 1997828774, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Sprite: {fileID: 362616440, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.6666667, y: 0.6111111}
+  m_Size: {x: 0.5555556, y: 0.6111111}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &-5788174390138871516
+--- !u!114 &7152277760729955073
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 815894738947505585}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 193bb340963074ddead5e1dafcbfc42a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  type: 4
+  type: 0
   OnDeleted:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/Exp_S.prefab.meta
+++ b/Assets/Prefabs/Exp_S.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fbacb30ff5c0c48a589139eb46c029d4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Health.prefab
+++ b/Assets/Prefabs/Health.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4514414920102664908
+--- !u!1 &744675329149044291
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,23 +8,23 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1700546527121884637}
-  - component: {fileID: 8419474527371356181}
-  - component: {fileID: -5788174390138871516}
+  - component: {fileID: 2351915754550946215}
+  - component: {fileID: 6135712667121464784}
+  - component: {fileID: 3623865189036204943}
   m_Layer: 0
-  m_Name: Mag
+  m_Name: Health
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1700546527121884637
+--- !u!4 &2351915754550946215
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 744675329149044291}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.9}
@@ -33,13 +33,13 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8419474527371356181
+--- !u!212 &6135712667121464784
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 744675329149044291}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -77,30 +77,30 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 1997828774, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
+  m_Sprite: {fileID: 934571490, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.6666667, y: 0.6111111}
+  m_Size: {x: 0.5555556, y: 0.6111111}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &-5788174390138871516
+--- !u!114 &3623865189036204943
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4514414920102664908}
+  m_GameObject: {fileID: 744675329149044291}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 193bb340963074ddead5e1dafcbfc42a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  type: 4
+  type: 3
   OnDeleted:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/Health.prefab.meta
+++ b/Assets/Prefabs/Health.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2251bf23f8b1849b5b626f75b7c6b119
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/enamy_0.prefab
+++ b/Assets/Prefabs/enamy_0.prefab
@@ -52,6 +52,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -89,7 +92,7 @@ SpriteRenderer:
   m_SpriteSortPoint: 0
 --- !u!95 &6618051547566022043
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -103,6 +106,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -116,6 +120,7 @@ CircleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1417766533275593788}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -139,9 +144,9 @@ CircleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
   m_Radius: 0.5
 --- !u!114 &6703226076764932479
 MonoBehaviour:
@@ -155,3 +160,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b41bc1532fe54b759e5b039d1d2dbaf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  param:
+    type: 0
+    hp: 10
+    speed: 1
+  OnDead:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Prefabs/enemy_1.prefab
+++ b/Assets/Prefabs/enemy_1.prefab
@@ -160,7 +160,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b41bc1532fe54b759e5b039d1d2dbaf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hp: 20
+  param:
+    type: 0
+    hp: 20
+    speed: 0.5
   OnDead:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Prefabs/enemy_1.prefab
+++ b/Assets/Prefabs/enemy_1.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   param:
-    type: 0
+    type: 1
     hp: 20
     speed: 0.5
   OnDead:

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -748,7 +748,7 @@ Transform:
   m_GameObject: {fileID: 365266724}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -7340,6 +7340,6 @@ SceneRoots:
   - {fileID: 412406948}
   - {fileID: 386879981}
   - {fileID: 1227936011}
-  - {fileID: 365266725}
   - {fileID: 961630574}
   - {fileID: 918975132}
+  - {fileID: 365266725}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -748,7 +748,7 @@ Transform:
   m_GameObject: {fileID: 365266724}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -3427,7 +3427,10 @@ MonoBehaviour:
   playerController: {fileID: 386879982}
   headerController: {fileID: 1429233481}
   prefab:
-  - {fileID: 11022837396415520, guid: 022891dd1112d45a58b6f056786abeb6, type: 3}
+  - {fileID: 815894738947505585, guid: fbacb30ff5c0c48a589139eb46c029d4, type: 3}
+  - {fileID: 3720869205308823430, guid: c6c4043fcffa9463ba57921278648389, type: 3}
+  - {fileID: 3589011983972985449, guid: eae9ac97ffa2e427cbdf830a65c1ede3, type: 3}
+  - {fileID: 744675329149044291, guid: 2251bf23f8b1849b5b626f75b7c6b119, type: 3}
   - {fileID: 4514414920102664908, guid: ab2a22ea485ad40e996b33703dbb21c6, type: 3}
   parent: {fileID: 1243791209}
 --- !u!4 &918975132

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -180,9 +180,6 @@ public class Enemy : BaseCharacter
                 // 武器と反対方向へノックバック
                 Vector2 dir = (this.transform.localPosition - collision.transform.localPosition).normalized;
                 setNockBack(dir);
-
-                //武器の名称
-                // Debug.Log("Weapon Hit : " + collision.name);
             }
         }
     }
@@ -206,7 +203,7 @@ public class Enemy : BaseCharacter
         // 死亡アニメーションが終わったら消滅
         if (status == Status.Dead) 
         {
-            expController.Spawn(this.transform.localPosition);
+            expController.Spawn(param.type, this.transform.localPosition);
             Destroy(this.gameObject);
         }
     }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -16,14 +16,30 @@ public class Enemy : BaseCharacter
         Hit,
         Dead
     }
-
     private Status status = Status.Init;
     public Status CurStatus { get => status; }
+
+    // タイプ
+    public enum Type
+    {
+        Normal_1 = 0,
+        Normal_2,
+        Boss
+    }
+
+    // パラメータ
+    [System.Serializable]
+    private struct TypeParam
+    {
+        public Type  type;
+        public int   hp;
+        public float speed;
+    }
+    [SerializeField] private TypeParam param;
 
     // 歩きパラメータ
     private const float MinInterval = 1.0f;
     private const float MaxInterval = 5.0f;
-    private const float WalkSpeed = 0.5f;
 
     // 歩き情報
     private struct Walk
@@ -44,8 +60,6 @@ public class Enemy : BaseCharacter
         public float timer;
     }
     private NockBack nockBack;
-
-    public int hp = 10;
 
     private float deadTime = 0.0f;
 
@@ -77,8 +91,8 @@ public class Enemy : BaseCharacter
                 AnimatorStateInfo stateInfo = animator.GetCurrentAnimatorStateInfo(0);
                 if (stateInfo.IsName("hit") && stateInfo.normalizedTime >= 1.0f)
                 {
-                    hp -= 10;   // ダメージ値（仮）
-                    if(hp > 0)
+                    param.hp -= 10;   // ダメージ値（仮）
+                    if(param.hp > 0)
                     {
                         setStatus(Status.Alive);
                     }
@@ -128,7 +142,7 @@ public class Enemy : BaseCharacter
         if (GameController.isPause) return;
 
         // 歩く
-        this.transform.localPosition += new Vector3(walkInfo.course.x * WalkSpeed * Time.deltaTime, walkInfo.course.y * WalkSpeed * Time.deltaTime, 0);
+        this.transform.localPosition += new Vector3(walkInfo.course.x * param.speed * Time.deltaTime, walkInfo.course.y * param.speed * Time.deltaTime, 0);
         // タイマー更新
         walkInfo.timer -= Time.deltaTime;
         // タイマーが０以下になったら再設定

--- a/Assets/Scripts/Exp.cs
+++ b/Assets/Scripts/Exp.cs
@@ -11,37 +11,42 @@ public class Exp : MonoBehaviour
     public ExpController.Type type;
 
     private PlayerController playerController;
-    private const float MoveSpeed = 4f;
+    private const float MoveSpeedSingle =  4f;
+    private const float MoveSpeedMulti  = 12f;
     private bool isMoving = false;
     public bool IsMoving { get => isMoving; }
+    private float moveSpeed = 0f;
 
     /// <summary>
     /// プレイヤーに向けて移動するトリガー
     /// </summary>
     /// <param name="playerController"></param>
-    public void Move(PlayerController playerController)
+    public void Move(PlayerController playerController, bool isSingle)
     {
         this.playerController = playerController;
         isMoving = true;
-        StartCoroutine(move());
+
+        moveSpeed = isSingle ? MoveSpeedSingle : MoveSpeedMulti;
     }
 
     /// <summary>
-    /// プレイヤーに向けて移動する処理
+    /// フレームワーク
     /// </summary>
-    /// <returns>コルーチン</returns>
-    private IEnumerator move()
+    private void Update()
     {
-        var elapsedTime = 0f;
-        var startPosition = transform.localPosition;
-        while (elapsedTime < 1f)
+        // ポーズ中はスキップ
+        if (GameController.isPause) return;
+
+        if (isMoving)
         {
             var targetPosition = playerController.GetPosition();
-            elapsedTime += Time.deltaTime * MoveSpeed;
-            transform.localPosition = Vector2.Lerp(startPosition, targetPosition, elapsedTime);
-            yield return null;
+            transform.localPosition = Vector2.MoveTowards(transform.localPosition, targetPosition, Time.deltaTime * moveSpeed);
+
+            if (Vector2.Distance(transform.localPosition, targetPosition) < 0.1f)
+            {
+                Destroy(gameObject);
+            }
         }
-        Destroy(gameObject);
     }
 
     /// <summary>

--- a/Assets/Scripts/Exp.cs
+++ b/Assets/Scripts/Exp.cs
@@ -8,6 +8,8 @@ using UnityEngine.Events;
 /// </summary>
 public class Exp : MonoBehaviour
 {
+    public ExpController.Type type;
+
     private PlayerController playerController;
     private const float MoveSpeed = 4f;
     private bool isMoving = false;

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -96,8 +96,7 @@ public class ExpController : MonoBehaviour
                 expNum += 10;
                 break;
             case Type.Health:
-                Debug.Log("Get Health");
-                // playerController.AddHp(1);
+                playerController.Heal();
                 break;
             case Type.Mag:
                 // 移動中でない exp オブジェクトをプレイヤーに向けて移動させる（マグネットは引き寄せられない）

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -24,7 +24,8 @@ public class ExpController : MonoBehaviour
 
     private List<GameObject> exps = new List<GameObject>();
 
-    private const float MoveThreshold = 2f;
+    private const float MoveThresholdSingle =  1f;
+    private const float MoveThresholdMulti  = 10f;
 
     // 経験値の取得数
     private int expNum = 0;
@@ -58,7 +59,7 @@ public class ExpController : MonoBehaviour
         // 経験値S, M の場合に、回復アイテム、マグネットになる可能性がある
         if(expType == Type.Exp_S || expType == Type.Exp_M)
         {
-            // 回復アイテム or マグネット
+            // 回復アイテム or マグネットを低確率で生成
             if(Random.Range(0, 100) < 1)
             {
                 // 回復アイテム 80%、マグネット 20%
@@ -100,13 +101,14 @@ public class ExpController : MonoBehaviour
                 break;
             case Type.Mag:
                 // 移動中でない exp オブジェクトをプレイヤーに向けて移動させる（マグネットは引き寄せられない）
+                Vector2 playerPos = playerController.GetPosition();
                 foreach (var obj in exps)
                 {
                     Exp e = obj.GetComponent<Exp>();
-
-                    if(e.type != Type.Mag && !e.IsMoving)
+                    float distance = Vector2.Distance(playerPos, obj.transform.localPosition);
+                    if(e.type != Type.Mag && !e.IsMoving && distance < MoveThresholdMulti)
                     {
-                        pull(obj);
+                        pull(obj, false);
                     }
     }
                 break;
@@ -132,9 +134,9 @@ public class ExpController : MonoBehaviour
             {
                 // プレイヤーとの距離を計算
                 float distance = Vector2.Distance(playerPos, obj.transform.localPosition);
-                if (distance < MoveThreshold)
+                if (distance < MoveThresholdSingle)
                 {
-                    pull(obj);
+                    pull(obj, true);
                 }
             }
         }
@@ -144,10 +146,10 @@ public class ExpController : MonoBehaviour
     /// 引き寄せ処理
     /// </summary>
     /// <param name="obj">対象のオブジェクト</param>
-    private void pull(GameObject obj)
+    private void pull(GameObject obj, bool isSingle)
     {
         Exp exp = obj.GetComponent<Exp>();
-        exp.Move(playerController);
+        exp.Move(playerController, isSingle);
         // 移動終了したらリストから削除
         exp.OnDeleted.AddListener(() => Remove(obj));
     }

--- a/Assets/Scripts/ExpController.cs
+++ b/Assets/Scripts/ExpController.cs
@@ -9,14 +9,11 @@ public class ExpController : MonoBehaviour
 {
     public enum Type
     {
-        Exp,    // 経験値
-        Mag     // マグネット
-    };
-
-    public struct ExpData
-    {
-        public Type         type;
-        public GameObject   obj;
+        Exp_S = 0,  // 経験値（小）
+        Exp_M,      // 経験値（中）
+        Exp_L,      // 経験値（大）
+        Health,     // HP 回復
+        Mag         // マグネット
     };
 
     [SerializeField] private PlayerController playerController;
@@ -25,7 +22,7 @@ public class ExpController : MonoBehaviour
     [SerializeField] private GameObject[] prefab;
     [SerializeField] private GameObject parent;
 
-    private List<ExpData> exps = new List<ExpData>();
+    private List<GameObject> exps = new List<GameObject>();
 
     private const float MoveThreshold = 2f;
 
@@ -37,58 +34,86 @@ public class ExpController : MonoBehaviour
     /// <summary>
     /// exp オブジェクトを生成する
     /// </summary>
+    /// <param name="enemyType">エネミータイプ</param>
     /// <param name="pos">配置座標</param>
-    public void Spawn(Vector2 pos)
+    public void Spawn(Enemy.Type enemyType, Vector2 pos)
     {
         headerController.AddDefeatCount();  // 討伐数をカウント
 
-        // マグネットが既に存在するか確認する
-        bool isExistMag = false;
-        foreach (var exp in exps)
+        // エネミータイプに応じて、経験値のタイプを変更
+        Type expType = Type.Exp_S;
+        switch(enemyType)
         {
-            if (exp.type == Type.Mag)
-            {
-                isExistMag = true;
+            case Enemy.Type.Normal_1:
+                expType = Type.Exp_S;
                 break;
-            }
+            case Enemy.Type.Normal_2:
+                expType = Type.Exp_M;
+                break;
+            case Enemy.Type.Boss:
+                expType = Type.Exp_L;
+                break;
         }
 
-        // 経験値が50を超えたら確率でマグネットを生成する
-        Type type = Type.Exp;
-        if (expNum >= 50 && !isExistMag)
+        // 経験値S, M の場合に、回復アイテム、マグネットになる可能性がある
+        if(expType == Type.Exp_S || expType == Type.Exp_M)
         {
-            if (Random.Range(0, 100) < 10)
+            // 回復アイテム or マグネット
+            if(Random.Range(0, 100) < 1)
             {
-                type = Type.Mag;
+                // 回復アイテム 80%、マグネット 20%
+                expType = Type.Health;
+                if(Random.Range(0, 100) < 20)
+                {
+                    expType = Type.Mag;
+                }
             }
         }
 
         // オブジェクト生成
-        var obj = Instantiate(prefab[(int)type], pos, Quaternion.identity, parent.transform);
-        exps.Add(new ExpData { type = type, obj = obj });
+        Vector3 expPos = new Vector3(pos.x, pos.y, 0.1f);
+        var obj = Instantiate(prefab[(int)expType], expPos, Quaternion.identity, parent.transform);
+        exps.Add(obj);
     }
 
     /// <summary>
     /// exp オブジェクトを削除する
     /// </summary>
-    /// <param name="exp">削除するオブジェクト</param>
-    public void Remove(ExpData exp)
+    /// <param name="curObj">削除対象のオブジェクト</param>
+    public void Remove(GameObject curObj)
     {
-        if (exp.type == Type.Exp) expNum++; // 経験値を取得
-        else {                              // マグネットの効果
-            // 移動中でない exp オブジェクトをプレイヤーに向けて移動させる
-            foreach (var e in exps)
-            {
-                GameObject obj = e.obj;
-                if (!obj.GetComponent<Exp>().IsMoving)
+        Exp exp = curObj.GetComponent<Exp>();
+        switch(exp.type)
+        {
+            case Type.Exp_S:
+                expNum += 1;
+                break;
+            case Type.Exp_M:
+                expNum += 2;
+                break;
+            case Type.Exp_L:
+                expNum += 10;
+                break;
+            case Type.Health:
+                Debug.Log("Get Health");
+                // playerController.AddHp(1);
+                break;
+            case Type.Mag:
+                // 移動中でない exp オブジェクトをプレイヤーに向けて移動させる（マグネットは引き寄せられない）
+                foreach (var obj in exps)
                 {
-                    pull(e);
-                }
-            }
+                    Exp e = obj.GetComponent<Exp>();
+
+                    if(e.type != Type.Mag && !e.IsMoving)
+                    {
+                        pull(obj);
+                    }
+    }
+                break;
         }
 
-        // 破棄
-        exps.Remove(exp);
+        // リストから破棄
+        exps.Remove(curObj);
     }
 
     /// <summary>
@@ -100,17 +125,16 @@ public class ExpController : MonoBehaviour
         if (GameController.isPause) return;
 
         Vector2 playerPos = playerController.GetPosition();
-        foreach (var exp in exps)
+        foreach (var obj in exps)
         {
             // 移動中でない場合
-            GameObject obj = exp.obj;
             if (!obj.GetComponent<Exp>().IsMoving)
             {
                 // プレイヤーとの距離を計算
                 float distance = Vector2.Distance(playerPos, obj.transform.localPosition);
                 if (distance < MoveThreshold)
                 {
-                    pull(exp);
+                    pull(obj);
                 }
             }
         }
@@ -119,12 +143,13 @@ public class ExpController : MonoBehaviour
     /// <summary>
     /// 引き寄せ処理
     /// </summary>
-    /// <param name="exp">Exp データ</param>
-    private void pull(ExpData exp)
+    /// <param name="obj">対象のオブジェクト</param>
+    private void pull(GameObject obj)
     {
-        exp.obj.GetComponent<Exp>().Move(playerController);
+        Exp exp = obj.GetComponent<Exp>();
+        exp.Move(playerController);
         // 移動終了したらリストから削除
-        exp.obj.GetComponent<Exp>().OnDeleted.AddListener(() => Remove(exp));
+        exp.OnDeleted.AddListener(() => Remove(obj));
     }
 
 }

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -33,7 +33,7 @@ public class GameController : MonoBehaviour
     private float holdTime = HoldTime;
 
     // 武器のレベルポイントが閾値を超えたら、武器レベルアップ（初期レベルは１で、９レベルまで）
-    private readonly int[] levelThreshold = { 0, 5, 10, 20, 30, 40, 60, 80, 100, 65535 };
+    private readonly int[] levelThreshold = { 0, 10, 25, 50, 100, 200, 300, 400, 500, 65535 };
 
     // 討伐数の閾値
     private const int DefeatThreshold = 2000;

--- a/Assets/Scripts/HeaderController.cs
+++ b/Assets/Scripts/HeaderController.cs
@@ -45,7 +45,9 @@ public class HeaderController : MonoBehaviour
     {
         expGauge.cur = cur;
         expGauge.max = max;
-        objExpGauge.localScale = new Vector3((float)expGauge.cur / expGauge.max, 1.0f, 1.0f);
+        // スケール値を算出（1.0 を超える場合は 1.0 にする）
+        float scl = (float)expGauge.cur / expGauge.max;
+        objExpGauge.localScale = new Vector3(scl > 1.0f ? 1.0f : scl, 1.0f, 1.0f);
     }
 
     /// <summary>

--- a/Assets/Scripts/HpGauge.cs
+++ b/Assets/Scripts/HpGauge.cs
@@ -33,9 +33,9 @@ public class HpGauge : MonoBehaviour
     /// ダメージ処理
     /// </summary>
     /// <param name="damage"></param> <summary>ダメージ量</summary>
-    public bool Hit(int damage)
+    public bool Damage(int damage)
     {
-        if(animTime > 0) return false;
+        if(animTime > 0) return false;  // 無敵時間
 
         bool isDead = false;
         tgt -= damage;
@@ -46,6 +46,17 @@ public class HpGauge : MonoBehaviour
         }
         animTime = AnimTime;
         return isDead;
+    }
+
+    /// <summary>
+    /// HP 回復
+    /// </summary>
+    /// <param name="value">回復量</param>
+    public void Heal(int value)
+    {
+        tgt += value;
+        if(tgt > max) tgt = max;
+        animTime = AnimTime;
     }
 
     /// <summary>

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -24,8 +24,9 @@ public class Player : BaseCharacter
 
     // HP 制御
     [SerializeField] private HpGauge hpGauge;
-    private const int HpInit   = 100;  // 初期 HP
+    private const int HpInit   = 100;   // 初期 HP
     private const int HPDamage =   2;   // ダメージ量
+    private const int HPHeal   =  10;   // 回復量
 
     // 武器１オブジェクト（デフォルト武器）
     [SerializeField] private GameObject weapon_1;
@@ -98,7 +99,7 @@ public class Player : BaseCharacter
             if(enemy.CurStatus != Enemy.Status.Dead)    // 死んでいない場合
             {
                 // Debug.Log("Player Hit : " + collision.name);
-                if(hpGauge.Hit(HPDamage))
+                if(hpGauge.Damage(HPDamage))
                 {
                     // 死亡処理
                     status = Status.Dead;
@@ -121,6 +122,14 @@ public class Player : BaseCharacter
     public bool IsDead()
     {
         return status == Status.Dead;
+    }
+
+    /// <summary>
+    /// HP 回復
+    /// </summary>
+    public void Heal()
+    {
+        hpGauge.Heal(HPHeal);
     }
 
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -52,9 +52,21 @@ public class PlayerController : MonoBehaviour
         player.SetDirection(dir);
     }
 
+    /// <summary>
+    /// 死亡確認
+    /// </summary>
+    /// <returns>true で死亡</returns>
     public bool IsDead()
     {
         return player.IsDead();
     }
-    
+
+    /// <summary>
+    /// HP 回復
+    /// </summary>    
+    public void Heal()
+    {
+        player.Heal();
+    }
+
 }


### PR DESCRIPTION
### エネミーの種類を定義
* エネミー１（HP:10, Speed:2）
* エネミー２（HP:20, Speed:1)
* ボス（未実装）

### 経験値の種類を増加
* 経験値（小）※ エネミー1 からドロップ
* 経験値（中）※ エネミー2 からドロップ
* 経験値（大）※ ドロップしない
* 回復薬 ※ 低確率でドロップ
* マグネット ※ さらに低確率でドロップ

### プレイヤーのHP 回復
* 回復薬ゲット時に HP を 10 回復

### 経験値の移動処理を見直し
* プレイヤーが近づいて取得（通常）と、マグネットでの取得でスピードを切り替え
* 移動処理をコルーチンから Update() に変更（ポーズ対応）