### PR TITLE
操作系をタッチ座標中心で行うように調整（カーソルアイコン表示含む）

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -773,6 +773,81 @@ MonoBehaviour:
   - {fileID: 1417766533275593788, guid: c5b459ee3e3f84ae99d028d6d403bcff, type: 3}
   - {fileID: 2194842702961310431, guid: 563dc165ab0364d1c8aca3c1f321217f, type: 3}
   parent: {fileID: 1714665915}
+--- !u!1 &369971116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 369971117}
+  - component: {fileID: 369971119}
+  - component: {fileID: 369971118}
+  m_Layer: 5
+  m_Name: dir
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &369971117
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369971116}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 784737211}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &369971118
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369971116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -1798395208, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &369971119
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 369971116}
+  m_CullTransparentMesh: 1
 --- !u!1 &386879980
 GameObject:
   m_ObjectHideFlags: 0
@@ -2864,6 +2939,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 779781468}
   m_CullTransparentMesh: 1
+--- !u!1 &784737210
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784737211}
+  - component: {fileID: 784737213}
+  - component: {fileID: 784737212}
+  m_Layer: 5
+  m_Name: base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &784737211
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784737210}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 369971117}
+  m_Father: {fileID: 1962903428}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &784737212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784737210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1328899968, guid: d71a3dc7aa20fad4f9a99fc76a9254ba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &784737213
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784737210}
+  m_CullTransparentMesh: 1
 --- !u!1 &832843613
 GameObject:
   m_ObjectHideFlags: 0
@@ -4457,6 +4608,7 @@ RectTransform:
   - {fileID: 1063520834}
   - {fileID: 1429233478}
   - {fileID: 1213697028}
+  - {fileID: 1962903428}
   m_Father: {fileID: 1922671363}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4652,6 +4804,7 @@ MonoBehaviour:
   fieldController: {fileID: 961630575}
   headerController: {fileID: 1429233481}
   resultController: {fileID: 1213697029}
+  cursorController: {fileID: 1962903429}
 --- !u!1 &1243791209
 GameObject:
   m_ObjectHideFlags: 0
@@ -7102,6 +7255,58 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1931353883}
   m_CullTransparentMesh: 1
+--- !u!1 &1962903427
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1962903428}
+  - component: {fileID: 1962903429}
+  m_Layer: 5
+  m_Name: Cursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1962903428
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962903427}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 784737211}
+  m_Father: {fileID: 1189105883}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1962903429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962903427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4668af17312c64f78a0566d81807bdaf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parts:
+  - {fileID: 784737210}
+  - {fileID: 369971116}
 --- !u!1 &2080994700
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CursorController.cs
+++ b/Assets/Scripts/CursorController.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+
+/// <summary>
+/// カーソル制御
+/// </summary>
+public class CursorController : MonoBehaviour
+{
+    /// <summary>
+    /// パーツ種類
+    /// </summary>
+    private enum Parts
+    {
+        Base = 0,   // 下敷き
+        Dir,        // 向き
+        Num
+    }
+    [SerializeField] private GameObject[] parts = new GameObject[(int)Parts.Num];
+
+    // センター座標
+    private Vector2 center;
+    // センター座標取得
+    public Vector2 Center { get { return center; } }
+
+    /// <summary>
+    /// センター座標設定（タッチ開始時）
+    /// </summary>
+    /// <param name="center">タッチ開始時の座標</param>
+    public void SetCenter(Vector2 center)
+    {
+        this.center = center;
+        parts[(int)Parts.Base].transform.localPosition = center;
+        activate(true);
+    }
+
+    /// <summary>
+    /// 座標更新（移動時）
+    /// </summary>
+    /// <param name="pos">現在のタッチ座標</param>
+    public void UpdatePosition(Vector2 pos)
+    {
+        // タッチ座標に応じて Dir の位置を調整
+        Vector2 offset = (pos - center).normalized * 8.0f;
+        parts[(int)Parts.Dir].transform.localPosition = offset;
+    }
+
+    /// <summary>
+    /// カーソル非表示
+    /// </summary>
+    public void Hide()
+    {
+        activate(false);
+    }
+
+    /// <summary>
+    /// オブジェクトアクティブ設定
+    /// </summary>
+    /// <param name="isActive">アクティブ状態</param>
+    private void activate(bool isActive)
+    {
+        // ベースオブジェクト（親）のみアクティブ設定
+        parts[(int)Parts.Base].SetActive(isActive);
+    }
+
+}

--- a/Assets/Scripts/CursorController.cs.meta
+++ b/Assets/Scripts/CursorController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4668af17312c64f78a0566d81807bdaf


### PR DESCRIPTION
### 操作系をタッチ座標中心で行う
* タッチ（した瞬間）の座標を中心座標とする
* タッチ中の座標とのベクトルで移動方向を決定する
* 補足：これまで画面中央からの相対座標で移動操作をしていた

### カーソル表示
* 上記対応に合わせて、画面に操作カーソルを表示する
